### PR TITLE
fix: adjust main page's Air Quality and Weather Overview boxes

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -2,171 +2,175 @@
 
 /* Dashboard Section Styling */
 .dashboard-section {
-    background: white;
-    border-radius: 16px;
-    padding: 2rem;
-    margin-bottom: 2rem;
-    box-shadow: 0 6px 25px rgba(0, 38, 58, 0.08);
-    border: 1px solid rgba(0, 38, 58, 0.1);
-    position: relative;
-    overflow: hidden;
+  background: white;
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 6px 25px rgba(0, 38, 58, 0.08);
+  border: 1px solid rgba(0, 38, 58, 0.1);
+  position: relative;
+  overflow: hidden;
 }
 
 .dashboard-section::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 4px;
-    background: linear-gradient(90deg, var(--usu-blue), var(--usu-light-blue), var(--usu-accent));
-    border-radius: 16px 16px 0 0;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(
+    90deg,
+    var(--usu-blue),
+    var(--usu-light-blue),
+    var(--usu-accent)
+  );
+  border-radius: 16px 16px 0 0;
 }
 
 /* Section Header */
 .section-header {
-    text-align: center;
-    margin-bottom: 2rem;
-    padding-bottom: 1rem;
-    border-bottom: 2px solid var(--usu-light-gray);
+  text-align: center;
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 2px solid var(--usu-light-gray);
 }
 
 .section-header h2 {
-    color: var(--usu-blue);
-    font-size: 1.6rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    margin: 0 0 0.5rem 0;
+  color: var(--usu-blue);
+  font-size: 1.6rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem 0;
 }
 
 .section-header h2 i {
-    color: var(--usu-light-blue);
+  color: var(--usu-light-blue);
 }
 
 .section-subtitle {
-    color: var(--usu-accent);
-    font-size: 1rem;
-    font-style: italic;
+  color: var(--usu-accent);
+  font-size: 1rem;
+  font-style: italic;
 }
 
 /* Dashboard Grid - Responsive auto-fit layout */
 .dashboard-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 450px), 1fr));
-    gap: 2rem;
-    align-items: start;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 450px), 1fr));
+  gap: 2rem;
 }
 
 /* Tablet adjustment - reduce minmax for earlier single-column switch */
 @media (max-width: 1024px) {
-    .dashboard-grid {
-        grid-template-columns: repeat(auto-fit, minmax(min(100%, 400px), 1fr));
-        gap: 1.5rem;
-    }
+  .dashboard-grid {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 400px), 1fr));
+    gap: 1.5rem;
+  }
 }
 
 /* Small tablets and large phones - force single column */
 @media (max-width: 768px) {
-    .dashboard-grid {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-    }
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
 
-    .dashboard-panel {
-        min-height: 400px; /* Reduce min-height on mobile */
-    }
+  .dashboard-panel {
+    min-height: 400px; /* Reduce min-height on mobile */
+  }
 }
 
 /* Ensure panels don't get too wide on very large displays */
 @media (min-width: 1800px) {
-    .dashboard-grid {
-        max-width: 1600px;
-        margin: 0 auto;
-    }
+  .dashboard-grid {
+    max-width: 1600px;
+    margin: 0 auto;
+  }
 }
 
 /* Dashboard Panels */
 .dashboard-panel {
-    background: linear-gradient(135deg, #f8f9fa, #f1f3f4);
-    border-radius: 12px;
-    padding: 1.5rem;
-    border: 1px solid rgba(0, 38, 58, 0.1);
-    transition: all 0.3s ease;
-    min-height: 500px;
-    display: flex;
-    flex-direction: column;
+  background: linear-gradient(135deg, #f8f9fa, #f1f3f4);
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 1px solid rgba(0, 38, 58, 0.1);
+  transition: all 0.3s ease;
+  min-height: 500px;
+  display: flex;
+  flex-direction: column;
 }
 
 .dashboard-panel:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 30px rgba(0, 38, 58, 0.12);
-    background: white;
+  transform: translateY(-4px);
+  box-shadow: 0 8px 30px rgba(0, 38, 58, 0.12);
+  background: white;
 }
 
 /* Panel Headers */
 .panel-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 1rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 2px solid var(--usu-light-gray);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid var(--usu-light-gray);
 }
 
 .panel-header h3 {
-    color: var(--usu-blue);
-    font-size: 1.2rem;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin: 0;
+  color: var(--usu-blue);
+  font-size: 1.2rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
 }
 
 .panel-header h3 i {
-    color: var(--usu-light-blue);
+  color: var(--usu-light-blue);
 }
 
 .panel-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3rem;
-    color: var(--usu-light-blue);
-    text-decoration: none;
-    font-size: 0.9rem;
-    font-weight: 500;
-    padding: 0.4rem 0.8rem;
-    border-radius: 6px;
-    background: rgba(98, 124, 139, 0.1);
-    transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--usu-light-blue);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  background: rgba(98, 124, 139, 0.1);
+  transition: all 0.2s ease;
 }
 
 .panel-link:hover {
-    background: var(--usu-light-blue);
-    color: white;
-    transform: translateY(-1px);
+  background: var(--usu-light-blue);
+  color: white;
+  transform: translateY(-1px);
 }
 
 /* Map Panel Specific */
 .map-panel {
-    border-left: 4px solid var(--usu-blue);
+  border-left: 4px solid var(--usu-blue);
 }
 
 .map-container-dashboard {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
 }
 
 .dashboard-map {
-    flex: 1;
-    border-radius: 8px;
-    box-shadow: 0 4px 15px rgba(0, 38, 58, 0.1);
-    border: 2px solid rgba(0, 38, 58, 0.1);
-    min-height: 350px;
-    width: 100%;
+  flex: 1;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 38, 58, 0.1);
+  border: 2px solid rgba(0, 38, 58, 0.1);
+  min-height: 350px;
+  width: 100%;
 }


### PR DESCRIPTION
Changed the align-items property from start to stretch in the "dashboard-grid" 
<img width="2256" height="1644" alt="www basinwx com_" src="https://github.com/user-attachments/assets/b1523629-556f-4d52-bcc0-ed0878298935" />
class to ensure the forecast-panel and map-panel stretch to equal height within their grid row while maintaining the existing minimum height.