### PR TITLE
HOTFIX: Remove mobile menu overlay (Safari navigation bug)

### DIFF
--- a/public/css/mobile.css
+++ b/public/css/mobile.css
@@ -21,21 +21,6 @@
     background: var(--usu-light-blue);
 }
 
-.mobile-menu-overlay {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 9999;
-}
-
-.mobile-menu-overlay.active {
-    display: block;
-}
-
 /* Tablet styles */
 @media screen and (max-width: 1024px) {
     .container {
@@ -286,7 +271,6 @@
     /* Dutch John easter egg mobile positioning */
     .dutch-john-easter-egg {
         top: 60px !important;
-        left: 10px !important;
         right: 10px !important;
         max-width: calc(100vw - 20px) !important;
         left: auto !important;

--- a/public/js/mobile-menu.js
+++ b/public/js/mobile-menu.js
@@ -4,14 +4,9 @@ function initializeMobileMenu() {
     menuToggle.className = 'mobile-menu-toggle';
     menuToggle.innerHTML = '<i class="fas fa-bars"></i>';
     menuToggle.setAttribute('aria-label', 'Toggle navigation menu');
-    
-    // Create overlay
-    const overlay = document.createElement('div');
-    overlay.className = 'mobile-menu-overlay';
-    
+
     // Add to body
     document.body.appendChild(menuToggle);
-    document.body.appendChild(overlay);
     
     // Get sidebar container
     const sidebarContainer = document.querySelector('.sidebar_container');
@@ -23,13 +18,11 @@ function initializeMobileMenu() {
         if (isActive) {
             // Close menu
             sidebarContainer.classList.remove('active');
-            overlay.classList.remove('active');
             menuToggle.innerHTML = '<i class="fas fa-bars"></i>';
             document.body.style.overflow = '';
         } else {
             // Open menu
             sidebarContainer.classList.add('active');
-            overlay.classList.add('active');
             menuToggle.innerHTML = '<i class="fas fa-times"></i>';
             document.body.style.overflow = 'hidden'; // Prevent scrolling when menu is open
         }
@@ -37,7 +30,6 @@ function initializeMobileMenu() {
     
     // Event listeners
     menuToggle.addEventListener('click', toggleMenu);
-    overlay.addEventListener('click', toggleMenu);
     
     // Close menu when clicking on a link (for better UX)
     const sidebarLinks = document.querySelectorAll('.sidebar-nav a');
@@ -45,7 +37,6 @@ function initializeMobileMenu() {
         link.addEventListener('click', function() {
             if (window.innerWidth <= 768) {
                 sidebarContainer.classList.remove('active');
-                overlay.classList.remove('active');
                 menuToggle.innerHTML = '<i class="fas fa-bars"></i>';
                 document.body.style.overflow = '';
             }
@@ -60,7 +51,6 @@ function initializeMobileMenu() {
             if (window.innerWidth > 768) {
                 // Reset menu state on larger screens
                 sidebarContainer.classList.remove('active');
-                overlay.classList.remove('active');
                 menuToggle.innerHTML = '<i class="fas fa-bars"></i>';
                 document.body.style.overflow = '';
             }


### PR DESCRIPTION
**Critical Fix:** Removes invisible overlay blocking navigation on mobile Safari.

**Changes:**
- Deletes `.mobile-menu-overlay` CSS and JS code
- 2 files: `mobile.css`, `mobile-menu.js`
- Total: +1/−27 lines

**Impact:** Fixes users trapped on roads page unable to navigate.

**Author:** @MichaelJosephDavies (cherry-picked from dev)

**Deploy immediately after merge.**