### PR TITLE
Made boxes on the main page the same size

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -57,7 +57,7 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 450px), 1fr));
     gap: 2rem;
-    align-items: start;
+    align-items: stretch;
 }
 
 /* Tablet adjustment - reduce minmax for earlier single-column switch */


### PR DESCRIPTION
This PR makes the boxes in the Air Quality and Weather Overview section of the main page of the website the same height.
This will help keep the layout of the page balanced.
Boxes may be different sizes on phone or tablet screens, but the page won't be unbalanced because they already stack vertically in those views.