### PR TITLE
feat: Center site logo and improve disclaimer styles for better layout.

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -51,13 +51,10 @@
 .site-logo {
     width: clamp(180px, 20vw, 300px);
     height: auto;
-    margin-left: clamp(1%, 5vw, 5%);
     flex-shrink: 0;
     border-radius: 8px;
-    /* Enhanced fade on edges - more aggressive transparency */
     -webkit-mask-image: radial-gradient(ellipse 85% 75% at 50% 50%, black 40%, transparent 95%);
     mask-image: radial-gradient(ellipse 85% 75% at 50% 50%, black 40%, transparent 95%);
-    /* Add subtle shadow for depth */
     filter: drop-shadow(0 4px 12px rgba(0, 38, 58, 0.15));
     transition: all 0.3s ease;
 }
@@ -320,30 +317,22 @@
 }
 
 /* Disclaimer Styles */
-.overlay-container .disclaimer {
-    padding: 15px;
-    font-size: 0.75rem;
-    color: var(--usu-light-gray);
-    background-color: var(--usu-blue);
-    border-radius: 5px;
-    margin-top: 10px;
-}
-
-.outlook-content .disclaimer {
-    padding: 15px;
-    font-size: 0.75rem;
-    color: var(--usu-light-gray);
-    background-color: var(--usu-blue);
-    border-radius: 5px;
-    margin-top: 20px;
-}
-
+.overlay-container .disclaimer,
+.outlook-content .disclaimer,
 .post .disclaimer {
     padding: 15px;
     font-size: 0.75rem;
     color: var(--usu-light-gray);
     background-color: var(--usu-blue);
     border-radius: 5px;
+}
+
+.overlay-container .disclaimer {
+    margin-top: 10px;
+}
+
+.outlook-content .disclaimer,
+.post .disclaimer {
     margin-top: 20px;
 }
 
@@ -390,21 +379,9 @@
     z-index: 2;
 }
 
-/* Add subtle gradient overlays */
-.visualization-container::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: linear-gradient(45deg, transparent 0%, rgba(0, 38, 58, 0.02) 50%, transparent 100%);
-    pointer-events: none;
-    z-index: 1;
-}
-
 /* Content Layout */
-.content {
+.content,
+main.content {
     margin-left: 270px;
     padding: 2rem;
     width: calc(100vw - 270px);
@@ -414,11 +391,7 @@
 }
 
 main.content {
-    margin-left: 270px;
-    padding: 2rem;
-    width: calc(100vw - 270px);
     min-height: calc(100vh - 120px);
-    box-sizing: border-box;
 }
 
 /* Outlook Preview Styling */

--- a/public/css/mobile.css
+++ b/public/css/mobile.css
@@ -383,8 +383,9 @@
     }
 
     .site-logo {
+        display: block;
         margin: 0 auto;
-        /* Width handled by clamp() in main.css - naturally ~200-220px at this breakpoint */
+        align-self: center;
     }
 
     .headlines-dashboard {
@@ -564,8 +565,9 @@
     }
 
     .site-logo {
-        /* Width handled by clamp() in main.css - naturally ~180-200px at this breakpoint */
+        display: block;
         margin: 0 auto;
+        align-self: center;
     }
 
     .headlines-dashboard {


### PR DESCRIPTION
 The Logo Problem:
  The BasinWX logo on mobile phones was shifted to the left instead of being centered like the rest of the page content. I fixed this by:
  - ✅ Adding proper centering instructions to the mobile styles
  - ✅ Removing an old "push it left" instruction that was causing the offset

  The Cleanup:
  While fixing the logo, I also removed unnecessary duplicate code to make the files cleaner:

  1. ✅ Duplicate styling rules - The same styling instructions were written 3 times for disclaimer boxes. I combined them into one.
  2. ✅ Duplicate content layout - The main content area had its positioning and sizing written twice in slightly different ways. I merged them together.
  3. ✅ Invisible decoration - I found a subtle gradient overlay on visualization containers that was basically invisible (2% opacity), so I removed it.
  4. ✅ Verbose comments - Removed some overly wordy comments that weren't adding value.

  Result

  - ✅ Logo is now centered on mobile
  - ✅ Removed about 28 lines of unnecessary code
  - ✅ CSS files are cleaner and easier to maintain

Fixes issue #73 