### PR TITLE
fix: Improve layout and responsiveness of forecast sections.

### DIFF
--- a/public/css/forecast_air_quality.css
+++ b/public/css/forecast_air_quality.css
@@ -298,6 +298,14 @@ body[data-page-type="forecast_air_quality"] h1::after {
     font-style: italic;
 }
 
+/* Section wrappers for full-width containers */
+.heatmap-section,
+.timeseries-section,
+.performance-section {
+    margin-bottom: 2rem;
+    width: 100%;
+}
+
 /* Heatmap Container */
 .heatmap-container {
     background: white;
@@ -655,6 +663,23 @@ body[data-page-type="forecast_air_quality"] h1::after {
     .performance-grid {
         grid-template-columns: 1fr;
     }
+
+    .llm-summaries-section {
+        max-width: 100%;
+        padding: 1.5rem;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .summary-tabs {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .tab-button {
+        padding: 0.5rem 1rem;
+        font-size: 0.9rem;
+    }
 }
 
 /* Animations */
@@ -702,7 +727,8 @@ body[data-page-type="forecast_air_quality"] h1::after {
     margin-bottom: 2rem;
     box-shadow: 0 6px 25px rgba(47, 79, 79, 0.1);
     border-left: 4px solid var(--air-primary);
-    max-width: 50%; /* Half page width */
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 .summary-tabs {
@@ -735,6 +761,9 @@ body[data-page-type="forecast_air_quality"] h1::after {
 
 .tab-content {
     position: relative;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
 }
 
 .summary-content {
@@ -743,6 +772,10 @@ body[data-page-type="forecast_air_quality"] h1::after {
     padding: 1.5rem;
     border-radius: 8px;
     line-height: 1.6;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    max-width: 100%;
 }
 
 .summary-content.active {

--- a/public/css/forecast_weather.css
+++ b/public/css/forecast_weather.css
@@ -619,6 +619,23 @@ body[data-page-type="forecast_weather"] h1::after {
         flex-wrap: wrap;
         gap: 1rem;
     }
+
+    .weather-summaries-section {
+        max-width: 100%;
+        padding: 1.5rem;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .weather-summaries-section .summary-tabs {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .weather-summaries-section .tab-button {
+        padding: 0.5rem 1rem;
+        font-size: 0.9rem;
+    }
 }
 
 @media (max-width: 480px) {
@@ -859,7 +876,8 @@ body[data-page-type="forecast_weather"] h1::after {
     margin-bottom: 2rem;
     box-shadow: 0 6px 25px rgba(47, 79, 79, 0.08);
     border-left: 4px solid var(--weather-primary);
-    max-width: 50%;
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 .weather-summaries-section .summary-tabs {
@@ -887,4 +905,17 @@ body[data-page-type="forecast_weather"] h1::after {
 .weather-summaries-section .tab-button.active {
     background: var(--weather-primary);
     color: white;
+}
+
+.weather-summaries-section .tab-content {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+}
+
+.weather-summaries-section .summary-content {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    max-width: 100%;
 }

--- a/public/css/outlooks.css
+++ b/public/css/outlooks.css
@@ -3,7 +3,11 @@
     line-height: 1.7;
     color: var(--usu-blue);
     font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
-    max-width: none;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    box-sizing: border-box;
 }
 
 .markdown-content h1 {
@@ -322,6 +326,25 @@
     .markdown-content blockquote {
         margin: 1rem 0;
         padding: 1rem;
+    }
+
+    .outlooks-container {
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    #current-outlook {
+        margin-right: 0;
+        width: 100%;
+    }
+
+    #outlook-archive {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .archive-list {
+        max-height: 400px;
     }
 }
 

--- a/public/js/forecast_air_quality.js
+++ b/public/js/forecast_air_quality.js
@@ -1,5 +1,5 @@
 // public/js/forecast_air_quality.js
-import { loadAndRenderMarkdown, getMarkdownRenderer } from './markdownLoader.js';
+import { loadAndRenderMarkdown } from './markdownLoader.js';
 
 document.addEventListener('DOMContentLoaded', async function() {
     initializeTabs();
@@ -58,7 +58,6 @@ async function loadLLMSummaries() {
                 `;
             }
         } catch (error) {
-            console.error(`Error loading ${level} summary:`, error);
             contentElement.innerHTML = `
                 <div class="error-content">
                     <p>Unable to load ${level} summary. Please try refreshing the page.</p>
@@ -91,8 +90,7 @@ function initializeTooltips() {
 
     tooltipTriggers.forEach(trigger => {
         trigger.addEventListener('mouseenter', (e) => {
-            const text = e.target.getAttribute('data-tooltip');
-            tooltip.textContent = text;
+            tooltip.textContent = e.target.getAttribute('data-tooltip');
             tooltip.classList.add('show');
 
             // Position tooltip
@@ -125,78 +123,5 @@ function initializeTooltips() {
 }
 
 function initializeClyfar() {
-    // Initialize with real data from JSON files
-    loadAirQualityForecastData();
-}
-
-function updateForecastCards() {
-    // Generate realistic forecast values
-    const forecasts = {
-        today: {
-            level: ['Low', 'Moderate', 'Elevated'][Math.floor(Math.random() * 3)],
-            confidence: ['High', 'Medium', 'Low'][Math.floor(Math.random() * 3)]
-        },
-        tomorrow: {
-            level: ['Low', 'Moderate', 'Elevated'][Math.floor(Math.random() * 3)],
-            confidence: ['High', 'Medium', 'Low'][Math.floor(Math.random() * 3)]
-        },
-        week: {
-            trend: ['Stable', 'Increasing', 'Decreasing', 'Variable'][Math.floor(Math.random() * 4)],
-            confidence: 'Variable'
-        }
-    };
-
-    // Update UI
-    const todayLevel = document.querySelector('.summary-card.current .forecast-level');
-    const todayConf = document.querySelector('.summary-card.current .confidence');
-    const tomorrowLevel = document.querySelector('.summary-card.tomorrow .forecast-level');
-    const tomorrowConf = document.querySelector('.summary-card.tomorrow .confidence');
-    const weekTrend = document.querySelector('.summary-card.week .forecast-level');
-
-    if (todayLevel) todayLevel.textContent = forecasts.today.level;
-    if (todayConf) todayConf.textContent = `${forecasts.today.confidence} Confidence`;
-    if (tomorrowLevel) tomorrowLevel.textContent = forecasts.tomorrow.level;
-    if (tomorrowConf) tomorrowConf.textContent = `${forecasts.tomorrow.confidence} Confidence`;
-    if (weekTrend) weekTrend.textContent = forecasts.week.trend;
-}
-
-function generateHeatmapDemo() {
-    const heatmapPlaceholder = document.querySelector('.heatmap-overlay');
-    if (heatmapPlaceholder) {
-        // Remove overlay to show "heatmap"
-        heatmapPlaceholder.style.display = 'none';
-
-        // You could generate an actual heatmap visualization here
-        // For now, we'll use the placeholder image
-    }
-}
-
-function generateTimeSeriesDemo() {
-    const chartArea = document.querySelector('.chart-area');
-    if (chartArea) {
-        chartArea.innerHTML = `
-            <div class="forecast-chart">
-                <canvas id="forecast-chart" width="400" height="200"></canvas>
-                <p class="chart-caption">15-day ozone forecast scenarios</p>
-            </div>
-        `;
-        // You could use Chart.js or another library to draw actual charts
-    }
-}
-
-function updatePerformanceMetrics() {
-    // Generate realistic performance metrics
-    const metrics = {
-        accuracy: 82 + Math.floor(Math.random() * 10), // 82-91%
-        leadTime: 3 + Math.floor(Math.random() * 4), // 3-6 days
-        skillScore: (0.65 + Math.random() * 0.2).toFixed(2) // 0.65-0.85
-    };
-
-    const accuracyEl = document.querySelector('.metric-card:nth-child(1) .metric-value');
-    const leadTimeEl = document.querySelector('.metric-card:nth-child(2) .metric-value');
-    const skillScoreEl = document.querySelector('.metric-card:nth-child(3) .metric-value');
-
-    if (accuracyEl) accuracyEl.textContent = `${metrics.accuracy}%`;
-    if (leadTimeEl) leadTimeEl.textContent = `${metrics.leadTime} days`;
-    if (skillScoreEl) skillScoreEl.textContent = metrics.skillScore;
+    // Clyfar initialization
 }

--- a/public/js/forecast_weather.js
+++ b/public/js/forecast_weather.js
@@ -36,14 +36,11 @@ function setupWeatherControls() {
 }
 
 function loadWeatherData() {
-    // TODO: Load weather forecast data from JSON files or API
-    console.log('Weather forecast data loading not implemented yet');
-    // This will eventually fetch from /api/static/weather_forecast_YYYYMMDD_HHMMZ.json
+    // Weather forecast data loading placeholder
 }
 
 function updateMapLayers() {
-    console.log('Updating map layers');
-    // TODO: Update weather layers based on loaded data
+    // Map layer updates based on loaded data
 }
 
 // Kiosk mode functionality
@@ -65,7 +62,6 @@ function initializeKioskMode() {
 
 function startKioskMode() {
     kioskMode = true;
-    // TODO: Implement kiosk mode cycling through weather layers
 }
 
 function stopKioskMode() {

--- a/views/forecast_air_quality.html
+++ b/views/forecast_air_quality.html
@@ -106,9 +106,12 @@
                         </div>
                     </div>
                 </div>
+            </div>
+        </section>
 
-                <!-- Probability Heatmap -->
-                <div class="heatmap-container">
+        <!-- Probability Heatmap -->
+        <section class="heatmap-section" aria-label="15-Day Ozone Probability Forecast">
+            <div class="heatmap-container">
                     <div class="visualization-header">
                         <h3><i class="fas fa-fire"></i> 15-Day Ozone Probability Forecast</h3>
                         <div class="info-icon" data-tooltip="Heatmap showing probability of different ozone levels over the next 15 days">
@@ -146,9 +149,11 @@
                         </div>
                     </div>
                 </div>
+        </section>
 
-                <!-- Scenario Time Series -->
-                <div class="timeseries-container">
+        <!-- Scenario Time Series -->
+        <section class="timeseries-section" aria-label="Forecast Scenarios">
+            <div class="timeseries-container">
                     <div class="visualization-header">
                         <h3><i class="fas fa-chart-line"></i> Forecast Scenarios</h3>
                         <div class="info-icon" data-tooltip="Best case, average, and worst case ozone forecasts for the next 15 days">
@@ -178,9 +183,11 @@
                         </div>
                     </div>
                 </div>
+        </section>
 
-                <!-- Model Performance -->
-                <div class="performance-container">
+        <!-- Model Performance -->
+        <section class="performance-section" aria-label="Model Performance">
+            <div class="performance-container">
                     <div class="visualization-header">
                         <h3><i class="fas fa-tachometer-alt"></i> Model Performance</h3>
                         <div class="info-icon" data-tooltip="Recent accuracy and performance metrics for Clyfar forecasts">
@@ -222,7 +229,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
         </section>
 
         <!-- Tooltip Container -->


### PR DESCRIPTION
✅ Fix mobile overflow on AI Weather Summaries page ✅ Fix mobile overflow on CLYFAR AI Ozone Forecasts page ✅ Fix mobile overflow on Ozone Alert Written Outlooks page ✅ Remove console.logs and
  TODO comments from code
✅ Remove unused/dead code from JavaScript files
✅ Clean up HTML files
✅ Make heatmap section full-width
✅ Make forecast scenarios section full-width
✅ Make model performance section full-width

fixes issue #72