### PR TITLE
Hide the scrollbar on the side panel without getting rid of scroll functionality

### DIFF
--- a/public/css/sidebar.css
+++ b/public/css/sidebar.css
@@ -18,12 +18,21 @@
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
-    overflow-y: auto;
 }
 
 .sidebar-nav {
     flex: 1;
+}
+
+.sidebar, .sidebar-nav {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
     overflow-y: auto;
+}
+
+.sidebar::-webkit-scrollbar,
+.sidebar-nav::-webkit-scrollbar {
+    display: none;
 }
 
 /* Sidebar Logo */


### PR DESCRIPTION
This PR hides the scrollbar on the navigation menu of the website.
The code suggested in the issue worked well and was probably the best and most well known solution.
Now users can scroll on the navigation menu without the scrollbar visible to cause an issue with the aesthetic.