### PR TITLE
fix: format fallback units correctly

### DIFF
--- a/public/js/roads/ConditionCards.js
+++ b/public/js/roads/ConditionCards.js
@@ -118,14 +118,14 @@ async function updateCardsWithFallback() {
         if (response.ok) {
             const data = await response.json();
             if (data && data.current) {
-                const tempF = Math.round(data.current.temperature * 9/5 + 32);
-                const windMph = Math.round(data.current.windSpeed * 2.237);
+                const tempC = data.current.temperature;
+                const windKmh = data.current.windSpeed;
 
                 const roadTempCard = document.querySelector('.condition-card-compact.road-temp .value');
-                if (roadTempCard) roadTempCard.textContent = unitsSystem.formatTemperature(tempF);
+                if (roadTempCard) roadTempCard.textContent = unitsSystem.formatTemperatureFromCelsius(tempC);
 
                 const windCard = document.querySelector('.condition-card-compact.wind .value');
-                if (windCard) windCard.textContent = unitsSystem.formatWindSpeed(windMph);
+                if (windCard) windCard.textContent = unitsSystem.formatWindSpeedFromKmh(windKmh);
             }
         }
     } catch (error) {

--- a/public/js/roads/UnitsSystem.js
+++ b/public/js/roads/UnitsSystem.js
@@ -31,6 +31,23 @@ class UnitsSystem {
     }
 
     /**
+     * Format temperature when input is in Celsius
+     * @param {number|string} celsius - Temperature in Celsius
+     * @returns {string} Formatted temperature string
+     */
+    formatTemperatureFromCelsius(celsius) {
+        if (celsius === '--' || celsius === null || celsius === undefined) return '--';
+        const temp = parseFloat(celsius);
+        if (isNaN(temp)) return '--';
+
+        if (this.isMetric) {
+            return `${temp.toFixed(1)}°C`;
+        }
+        const fahrenheit = temp * 9/5 + 32;
+        return `${fahrenheit.toFixed(1)}°F`;
+    }
+
+    /**
      * Format wind speed with current unit system
      * @param {number|string} mph - Wind speed in miles per hour
      * @returns {string} Formatted wind speed string
@@ -45,6 +62,23 @@ class UnitsSystem {
             return `${kmh.toFixed(1)} km/h`;
         }
         return `${speed.toFixed(1)} mph`;
+    }
+
+    /**
+     * Format wind speed when input is in km/h
+     * @param {number|string} kmh - Wind speed in kilometers per hour
+     * @returns {string} Formatted wind speed string
+     */
+    formatWindSpeedFromKmh(kmh) {
+        if (kmh === '--' || kmh === null || kmh === undefined) return '--';
+        const speed = parseFloat(kmh);
+        if (isNaN(speed)) return '--';
+
+        if (this.isMetric) {
+            return `${speed.toFixed(1)} km/h`;
+        }
+        const mph = speed / 1.60934;
+        return `${mph.toFixed(1)} mph`;
     }
 
     /**


### PR DESCRIPTION
## Summary\n- Format Open-Meteo fallback temperature and wind with the selected units\n\n## Testing\n- npm run test