### PR TITLE
Fix camera ring cold-start with warm restore + add lifecycle email alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,41 @@ curl -s https://basinwx.com/api/filelist/forecasts | jq 'length'
 ssh akamai "pm2 logs --lines 50"
 ```
 
+### Automated Email Report
+The server can send a scheduled monitoring report email (pipeline status + camera scheduler stats).
+
+Set these environment variables on the server:
+```bash
+REPORT_EMAIL_ENABLED=true
+REPORT_EMAIL_TO=you@example.com
+REPORT_EMAIL_FROM=basinwx@example.com
+REPORT_EMAIL_SMTP_HOST=smtp.example.com
+REPORT_EMAIL_SMTP_PORT=587
+REPORT_EMAIL_SMTP_SECURE=false
+REPORT_EMAIL_SMTP_USER=your-smtp-user
+REPORT_EMAIL_SMTP_PASS=your-smtp-password
+REPORT_EMAIL_SCHEDULE_ENABLED=false
+REPORT_EMAIL_CRON="0 8 * * *"
+REPORT_EMAIL_TIMEZONE=America/Denver
+REPORT_EMAIL_NOTIFY_ON_STARTUP=true
+REPORT_EMAIL_NOTIFY_ON_SHUTDOWN=true
+REPORT_EMAIL_SUBJECT_PREFIX="BasinWx Status Report"
+```
+
+Notes:
+- `REPORT_EMAIL_CRON` uses standard 5-field cron format.
+- Lifecycle reports are controlled by `REPORT_EMAIL_NOTIFY_ON_STARTUP` and `REPORT_EMAIL_NOTIFY_ON_SHUTDOWN`.
+- Scheduled reports are optional and require `REPORT_EMAIL_SCHEDULE_ENABLED=true`.
+- Service is disabled unless `REPORT_EMAIL_ENABLED=true`.
+
+Warm-restore metric endpoint:
+```bash
+curl -s https://basinwx.com/api/road-weather/camera-scheduler-status | jq '.warmRestore'
+```
+Returns startup restore diagnostics including:
+- `restoredDetectionsCount`
+- `restoredSnapshotAgeMinutes`
+
 ### Storage Triage
 ```bash
 # Find GEFS cache hogs
@@ -194,4 +229,3 @@ Other than JRL's [email address](mailto:john.lawson@usu.edu), further informatio
 - Ozone Alert program for receiving email outlooks when there is a elevated risk of **high wintertime ozone** in the Uinta Basin.
 - GitHub Issues: [Report bugs or request features (more for the tech-minded)](https://github.com/bingham-research-center/ubair-website/issues)
 ---
-

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node-cache": "^5.1.2",
     "node-cron": "^3.0.3",
     "node-fetch": "^3.3.2",
+    "nodemailer": "^6.10.1",
     "plotly.js": "^2.35.3",
     "plotly.js-dist": "^2.35.2",
     "react-plotly.js": "^2.6.0",

--- a/server/__tests__/cameraAnalysisScheduler.test.js
+++ b/server/__tests__/cameraAnalysisScheduler.test.js
@@ -61,6 +61,15 @@ describe('CameraAnalysisScheduler', () => {
             expect(scheduler.weatherStations).toEqual(stations);
         });
 
+        it('should increase cache TTL for large camera queues', () => {
+            const cameras = Array.from({ length: 145 }, (_, i) => ({ id: i + 1, name: `Camera ${i + 1}` }));
+
+            scheduler.updateCameraList(cameras, []);
+
+            expect(scheduler.cacheTTLSeconds).toBeGreaterThan(600);
+            expect(scheduler.cacheTTLSeconds).toBe(4950);
+        });
+
         it('should handle empty camera list', () => {
             scheduler.updateCameraList([], []);
 
@@ -104,6 +113,16 @@ describe('CameraAnalysisScheduler', () => {
             expect(results).toHaveLength(2);
             expect(scheduler.stats.cacheHits).toBe(1);
         });
+
+        it('should read individual cached results when camera queue is empty', () => {
+            scheduler.cache.set('camera_1', { cameraId: '1', snowDetected: true });
+
+            const results = scheduler.getCachedResults();
+
+            expect(results).toHaveLength(1);
+            expect(results[0].cameraId).toBe('1');
+            expect(scheduler.stats.cacheHits).toBe(1);
+        });
     });
 
     describe('API Call Rate Calculation', () => {
@@ -145,8 +164,18 @@ describe('CameraAnalysisScheduler', () => {
             expect(stats).toHaveProperty('cacheHits');
             expect(stats).toHaveProperty('cacheMisses');
             expect(stats).toHaveProperty('cacheHitRate');
+            expect(stats).toHaveProperty('warmRestore');
             expect(stats).toHaveProperty('estimatedApiCallsPerHour');
             expect(stats).toHaveProperty('config');
+        });
+
+        it('should expose warm-restore defaults when no disk restore occurred', () => {
+            const stats = scheduler.getStats();
+
+            expect(stats.warmRestore.enabled).toBe(false);
+            expect(stats.warmRestore.restoredFromDisk).toBe(false);
+            expect(stats.warmRestore.restoredDetectionsCount).toBe(0);
+            expect(stats.warmRestore.restoredSnapshotAgeMinutes).toBeNull();
         });
 
         it('should calculate cache hit rate correctly', () => {

--- a/server/cameraAnalysisScheduler.js
+++ b/server/cameraAnalysisScheduler.js
@@ -4,27 +4,38 @@
  * Staggered camera snow detection analysis to avoid UDOT API rate limits.
  * 
  * Problem: Analyzing all 20-30 cameras on every request = 60-90 API calls
- * Solution: Analyze 1 camera every 30 seconds in background, cache results for 10 minutes
+ * Solution: Analyze 1 camera every 30 seconds in background, keep restart-safe cached results
  * 
  * Rate Limit: UDOT allows 10 calls/60 seconds (600 calls/hour)
  * Our usage: ~1 camera * 3 views every 30s = ~3 calls/30s = ~360 calls/hour (60% of limit)
  * 
  * Features:
- * - Batch-level caching (10 minute TTL)
+ * - Dynamic cache TTL based on full camera rotation time
  * - Staggered analysis (1 camera every 30 seconds)
  * - Keep all 3 views per camera (multi-view consensus)
+ * - Persist/restore detections across restarts
  * - User requests served from cache (instant, no API calls)
  */
 
 import NodeCache from 'node-cache';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import path from 'path';
 import SnowDetectionService from './snowDetectionService.js';
 
+const DEFAULT_CACHE_TTL_SECONDS = 600;
+const PERSISTED_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+const CACHE_DIR = path.join(process.cwd(), '.cache');
+const PERSISTED_CACHE_FILE = path.join(CACHE_DIR, 'camera_detections.json');
+
 class CameraAnalysisScheduler {
-    constructor() {
+    constructor(options = {}) {
         this.snowDetectionService = new SnowDetectionService();
+        this.enablePersistence = options.enablePersistence ?? process.env.NODE_ENV !== 'test';
         
         // Cache for complete camera analysis results (10 minute TTL)
-        this.cache = new NodeCache({ stdTTL: 600, checkperiod: 60 });
+        this.cache = new NodeCache({ stdTTL: DEFAULT_CACHE_TTL_SECONDS, checkperiod: 60 });
+        this.cacheTTLSeconds = DEFAULT_CACHE_TTL_SECONDS;
         
         // Queue of cameras to analyze
         this.cameraQueue = [];
@@ -39,7 +50,9 @@ class CameraAnalysisScheduler {
         this.config = {
             batchSize: 1,           // Analyze 1 camera per cycle (conservative for rate limits)
             intervalSeconds: 30,    // Run every 30 seconds
-            maxRetries: 3           // Retry failed analyses
+            maxRetries: 3,          // Retry failed analyses
+            baseCacheTTLSeconds: DEFAULT_CACHE_TTL_SECONDS,
+            rotationBufferSeconds: 600
         };
         
         // Statistics
@@ -51,6 +64,22 @@ class CameraAnalysisScheduler {
             lastAnalysisTime: null,
             averageAnalysisTime: 0
         };
+
+        // Warm-restore state for startup diagnostics
+        this.warmRestore = {
+            enabled: this.enablePersistence,
+            restoredFromDisk: false,
+            restoredDetectionsCount: 0,
+            restoredSnapshotSavedAt: null,
+            restoredSnapshotAgeMinutes: null,
+            restoredAt: null,
+            skippedStaleSnapshot: false,
+            restoreError: null
+        };
+
+        if (this.enablePersistence) {
+            this.restorePersistedDetections();
+        }
     }
     
     /**
@@ -64,7 +93,7 @@ class CameraAnalysisScheduler {
         
         console.log('🎥 Starting camera analysis scheduler...');
         console.log(`   Analyzing ${this.config.batchSize} camera(s) every ${this.config.intervalSeconds}s`);
-        console.log('   Results cached for 10 minutes');
+        console.log(`   Results cached for up to ${Math.ceil(this.cacheTTLSeconds / 60)} minutes`);
         console.log('   All 3 camera views analyzed for multi-view consensus\n');
         
         this.isRunning = true;
@@ -96,6 +125,12 @@ class CameraAnalysisScheduler {
         }
         
         this.isRunning = false;
+
+        if (this.enablePersistence) {
+            this.persistCachedResults().catch((error) => {
+                console.warn(`   ⚠️ Failed to persist camera detections on stop: ${error.message}`);
+            });
+        }
         
         console.log('✓ Camera analysis scheduler stopped\n');
     }
@@ -105,10 +140,18 @@ class CameraAnalysisScheduler {
      * Called by background refresh service when new data arrives
      */
     updateCameraList(cameras, weatherStations = []) {
+        const previousCameraCount = this.cameraQueue.length;
+        const previousTTL = this.cacheTTLSeconds;
+
         this.cameraQueue = cameras;
         this.weatherStations = weatherStations;
+        this.cacheTTLSeconds = this.calculateCacheTTLSeconds(cameras.length);
         
         console.log(`   Updated camera queue: ${cameras.length} cameras`);
+
+        if (previousCameraCount !== cameras.length || previousTTL !== this.cacheTTLSeconds) {
+            console.log(`   Camera detection TTL: ${Math.ceil(this.cacheTTLSeconds / 60)} minutes`);
+        }
     }
     
     /**
@@ -150,7 +193,7 @@ class CameraAnalysisScheduler {
             // Update cache with results
             results.forEach(result => {
                 const cacheKey = `camera_${result.cameraId}`;
-                this.cache.set(cacheKey, result);
+                this.cache.set(cacheKey, result, this.cacheTTLSeconds);
             });
             
             const duration = Date.now() - startTime;
@@ -169,6 +212,12 @@ class CameraAnalysisScheduler {
             if (this.currentBatch * this.config.batchSize >= this.cameraQueue.length) {
                 this.currentBatch = 0;
                 this.updateBatchCache();
+            }
+
+            if (this.enablePersistence) {
+                this.persistCachedResults().catch((error) => {
+                    console.warn(`   ⚠️ Failed to persist camera detections: ${error.message}`);
+                });
             }
             
         } catch (error) {
@@ -191,8 +240,8 @@ class CameraAnalysisScheduler {
             }
         });
         
-        // Store complete batch result with 10 minute cache
-        this.cache.set('all_camera_detections', allResults, 600);
+        // Store complete batch result with dynamic cache TTL
+        this.cache.set('all_camera_detections', allResults, this.cacheTTLSeconds);
         
         console.log(`   ✓ Updated batch cache: ${allResults.length} cameras`);
     }
@@ -202,23 +251,8 @@ class CameraAnalysisScheduler {
      * Called by roadWeatherService when user requests data
      */
     getCachedResults() {
-        // Try to get complete batch first (most efficient)
-        const batchResults = this.cache.get('all_camera_detections');
-        if (batchResults) {
-            this.stats.cacheHits++;
-            return batchResults;
-        }
-        
-        // Fall back to individual camera results
-        const results = [];
-        this.cameraQueue.forEach(camera => {
-            const cacheKey = `camera_${camera.id}`;
-            const result = this.cache.get(cacheKey);
-            if (result) {
-                results.push(result);
-            }
-        });
-        
+        const results = this.getCachedResultsSnapshot();
+
         if (results.length > 0) {
             this.stats.cacheHits++;
             return results;
@@ -228,12 +262,209 @@ class CameraAnalysisScheduler {
         this.stats.cacheMisses++;
         return [];
     }
+
+    /**
+     * Read cached detections without mutating cache hit/miss statistics.
+     */
+    getCachedResultsSnapshot() {
+        const batchResults = this.filterDetectionsForActiveCameras(this.cache.get('all_camera_detections'));
+        const individualResults = this.getIndividualCachedResults();
+
+        if (batchResults.length === 0) {
+            return individualResults;
+        }
+
+        if (individualResults.length === 0) {
+            return batchResults;
+        }
+
+        const mergedResults = new Map(batchResults.map((result) => [result.cameraId, result]));
+        individualResults.forEach((result) => {
+            mergedResults.set(result.cameraId, result);
+        });
+
+        if (this.cameraQueue.length > 0) {
+            return this.cameraQueue
+                .map((camera) => mergedResults.get(camera.id.toString()))
+                .filter(Boolean);
+        }
+
+        return Array.from(mergedResults.values());
+    }
+
+    /**
+     * Calculate cache TTL based on full camera rotation time.
+     * Ensures detections do not expire before the scheduler cycles back.
+     */
+    calculateCacheTTLSeconds(cameraCount = this.cameraQueue.length) {
+        if (cameraCount <= 0) {
+            return this.config.baseCacheTTLSeconds;
+        }
+
+        const cyclesPerRotation = Math.ceil(cameraCount / this.config.batchSize);
+        const fullRotationSeconds = cyclesPerRotation * this.config.intervalSeconds;
+
+        return Math.max(
+            this.config.baseCacheTTLSeconds,
+            fullRotationSeconds + this.config.rotationBufferSeconds
+        );
+    }
+
+    /**
+     * Normalize detection shape and ensure consistent camera ID formatting.
+     */
+    normalizeDetection(detection) {
+        if (!detection || detection.cameraId === undefined || detection.cameraId === null) {
+            return null;
+        }
+
+        return {
+            ...detection,
+            cameraId: detection.cameraId.toString()
+        };
+    }
+
+    /**
+     * Filter detections to active cameras when camera list is available.
+     */
+    filterDetectionsForActiveCameras(detections) {
+        if (!Array.isArray(detections) || detections.length === 0) {
+            return [];
+        }
+
+        const normalizedDetections = detections
+            .map((detection) => this.normalizeDetection(detection))
+            .filter(Boolean);
+
+        if (this.cameraQueue.length === 0) {
+            return normalizedDetections;
+        }
+
+        const activeCameraIds = new Set(this.cameraQueue.map((camera) => camera.id.toString()));
+        return normalizedDetections.filter((detection) => activeCameraIds.has(detection.cameraId));
+    }
+
+    /**
+     * Collect individual camera detections from cache.
+     */
+    getIndividualCachedResults() {
+        const results = [];
+        const seen = new Set();
+
+        const cameraIds = this.cameraQueue.length > 0
+            ? this.cameraQueue.map((camera) => camera.id.toString())
+            : this.cache.keys()
+                .filter((key) => key.startsWith('camera_'))
+                .map((key) => key.replace('camera_', ''));
+
+        cameraIds.forEach((cameraId) => {
+            if (seen.has(cameraId)) {
+                return;
+            }
+
+            const result = this.normalizeDetection(this.cache.get(`camera_${cameraId}`));
+            if (result) {
+                seen.add(cameraId);
+                results.push(result);
+            }
+        });
+
+        return results;
+    }
+
+    /**
+     * Restore persisted detections from disk to avoid gray icons after restart.
+     */
+    restorePersistedDetections() {
+        try {
+            if (!fsSync.existsSync(PERSISTED_CACHE_FILE)) {
+                return;
+            }
+
+            const fileContent = fsSync.readFileSync(PERSISTED_CACHE_FILE, 'utf8');
+            const payload = JSON.parse(fileContent);
+
+            if (!payload || !Array.isArray(payload.detections) || payload.detections.length === 0) {
+                return;
+            }
+
+            const savedAt = Number(payload.savedAt);
+            if (savedAt && (Date.now() - savedAt) > PERSISTED_CACHE_MAX_AGE_MS) {
+                this.warmRestore.skippedStaleSnapshot = true;
+                this.warmRestore.restoredSnapshotSavedAt = new Date(savedAt).toISOString();
+                this.warmRestore.restoredSnapshotAgeMinutes = Math.round((Date.now() - savedAt) / (1000 * 60));
+                console.log('   Cached camera detections on disk are stale; skipping restore');
+                return;
+            }
+
+            const restoredDetections = payload.detections
+                .map((detection) => this.normalizeDetection(detection))
+                .filter(Boolean);
+
+            if (restoredDetections.length === 0) {
+                return;
+            }
+
+            const persistedTTL = Number(payload.ttlSeconds);
+            const restoredTTL = Math.max(
+                this.config.baseCacheTTLSeconds,
+                Number.isFinite(persistedTTL) ? persistedTTL : this.config.baseCacheTTLSeconds
+            );
+
+            this.cacheTTLSeconds = restoredTTL;
+
+            restoredDetections.forEach((result) => {
+                this.cache.set(`camera_${result.cameraId}`, result, restoredTTL);
+            });
+            this.cache.set('all_camera_detections', restoredDetections, restoredTTL);
+
+            const ageMinutes = savedAt
+                ? Math.round((Date.now() - savedAt) / (1000 * 60))
+                : 'unknown';
+
+            this.warmRestore.restoredFromDisk = true;
+            this.warmRestore.restoredDetectionsCount = restoredDetections.length;
+            this.warmRestore.restoredSnapshotSavedAt = savedAt ? new Date(savedAt).toISOString() : null;
+            this.warmRestore.restoredSnapshotAgeMinutes = Number.isFinite(ageMinutes) ? ageMinutes : null;
+            this.warmRestore.restoredAt = new Date().toISOString();
+            this.warmRestore.restoreError = null;
+
+            console.log(`   ✓ Restored ${restoredDetections.length} camera detections from disk cache (age: ${ageMinutes} min)`);
+        } catch (error) {
+            this.warmRestore.restoreError = error.message;
+            console.warn(`   ⚠️ Failed to restore camera detections from disk: ${error.message}`);
+        }
+    }
+
+    /**
+     * Persist cached detections to disk for restart-safe warm state.
+     */
+    async persistCachedResults() {
+        const detections = this.getCachedResultsSnapshot();
+        if (detections.length === 0) {
+            return;
+        }
+
+        try {
+            await fs.mkdir(CACHE_DIR, { recursive: true });
+            const payload = {
+                savedAt: Date.now(),
+                ttlSeconds: this.cacheTTLSeconds,
+                detections
+            };
+
+            await fs.writeFile(PERSISTED_CACHE_FILE, JSON.stringify(payload), 'utf8');
+        } catch (error) {
+            console.warn(`   ⚠️ Failed to save camera detections to disk: ${error.message}`);
+        }
+    }
     
     /**
      * Get scheduler statistics
      */
     getStats() {
         const cacheStats = this.cache.getStats();
+        const hasBatchCache = Boolean(this.cache.get('all_camera_detections'));
         
         return {
             isRunning: this.isRunning,
@@ -248,7 +479,9 @@ class CameraAnalysisScheduler {
                 : 'N/A',
             lastAnalysisTime: this.stats.lastAnalysisTime,
             averageAnalysisTime: Math.round(this.stats.averageAnalysisTime) + 'ms',
-            cachedCameras: cacheStats.keys - 1, // Subtract 1 for batch cache key
+            cachedCameras: Math.max(0, cacheStats.keys - (hasBatchCache ? 1 : 0)),
+            cacheTTLMinutes: Math.ceil(this.cacheTTLSeconds / 60),
+            warmRestore: { ...this.warmRestore },
             estimatedApiCallsPerHour: this.calculateApiCallRate(),
             config: this.config
         };
@@ -293,6 +526,7 @@ class CameraAnalysisScheduler {
         console.log(`  Cache Misses: ${stats.cacheMisses}`);
         console.log(`  Hit Rate: ${stats.cacheHitRate}`);
         console.log(`  Cached Cameras: ${stats.cachedCameras}`);
+        console.log(`  Cache TTL: ${stats.cacheTTLMinutes} minutes`);
         console.log('');
         console.log('Rate Limit:');
         console.log(`  Estimated API Calls/Hour: ${stats.estimatedApiCallsPerHour}`);

--- a/server/reportEmailService.js
+++ b/server/reportEmailService.js
@@ -1,0 +1,314 @@
+import cron from 'node-cron';
+
+function parseBoolean(value, fallback = false) {
+    if (value === undefined || value === null || value === '') {
+        return fallback;
+    }
+
+    return ['1', 'true', 'yes', 'on'].includes(String(value).toLowerCase());
+}
+
+class ReportEmailService {
+    constructor(options = {}) {
+        this.getStatusReport = options.getStatusReport || (() => ({}));
+        this.getBackgroundStats = options.getBackgroundStats || (() => null);
+        this.getCameraStats = options.getCameraStats || (() => null);
+
+        this.job = null;
+        this.transporter = null;
+
+        this.config = {
+            enabled: parseBoolean(process.env.REPORT_EMAIL_ENABLED, false),
+            smtpHost: process.env.REPORT_EMAIL_SMTP_HOST || '',
+            smtpPort: Number.parseInt(process.env.REPORT_EMAIL_SMTP_PORT || '587', 10),
+            smtpSecure: parseBoolean(process.env.REPORT_EMAIL_SMTP_SECURE, false),
+            smtpUser: process.env.REPORT_EMAIL_SMTP_USER || '',
+            smtpPass: process.env.REPORT_EMAIL_SMTP_PASS || '',
+            from: process.env.REPORT_EMAIL_FROM || process.env.REPORT_EMAIL_SMTP_USER || '',
+            to: process.env.REPORT_EMAIL_TO || '',
+            scheduleEnabled: parseBoolean(process.env.REPORT_EMAIL_SCHEDULE_ENABLED, false),
+            cron: process.env.REPORT_EMAIL_CRON || '0 8 * * *',
+            timezone: process.env.REPORT_EMAIL_TIMEZONE || 'America/Denver',
+            notifyOnStartup: parseBoolean(
+                process.env.REPORT_EMAIL_NOTIFY_ON_STARTUP,
+                parseBoolean(process.env.REPORT_EMAIL_SEND_ON_STARTUP, true)
+            ),
+            notifyOnShutdown: parseBoolean(process.env.REPORT_EMAIL_NOTIFY_ON_SHUTDOWN, true),
+            subjectPrefix: process.env.REPORT_EMAIL_SUBJECT_PREFIX || 'BasinWx Status Report'
+        };
+    }
+
+    start() {
+        if (!this.config.enabled) {
+            console.log('✉️  Report email service disabled (set REPORT_EMAIL_ENABLED=true to enable)');
+            return;
+        }
+
+        if (this.job) {
+            console.log('⚠️  Report email service already running');
+            return;
+        }
+
+        const missingConfig = this.getMissingConfig();
+        if (missingConfig.length > 0) {
+            console.warn(`⚠️  Report email service missing configuration: ${missingConfig.join(', ')}`);
+            return;
+        }
+
+        if (this.config.notifyOnStartup) {
+            this.sendLifecycleNotification('startup', {
+                signal: 'process_start',
+                pid: process.pid,
+                uptimeSeconds: Math.round(process.uptime())
+            }).catch((error) => {
+                console.error(`✗ Startup report email failed: ${error.message}`);
+            });
+        }
+
+        if (!this.config.scheduleEnabled) {
+            console.log('✉️  Report email schedule disabled (set REPORT_EMAIL_SCHEDULE_ENABLED=true to enable cron)');
+            return;
+        }
+
+        if (!cron.validate(this.config.cron)) {
+            console.warn(`⚠️  Invalid REPORT_EMAIL_CRON: ${this.config.cron}`);
+            return;
+        }
+
+        this.job = cron.schedule(this.config.cron, async () => {
+            try {
+                await this.sendReportEmail('scheduled');
+            } catch (error) {
+                console.error(`✗ Scheduled report email failed: ${error.message}`);
+            }
+        }, {
+            timezone: this.config.timezone
+        });
+
+        console.log(`✉️  Report email schedule enabled (${this.config.cron}, timezone ${this.config.timezone})`);
+    }
+
+    stop() {
+        if (!this.job) {
+            return;
+        }
+
+        this.job.stop();
+        this.job = null;
+
+        console.log('✉️  Report email service stopped');
+    }
+
+    async sendReportEmail(trigger = 'manual') {
+        return this.sendReportEmailWithContext(trigger, {});
+    }
+
+    async sendReportEmailWithContext(trigger = 'manual', context = {}) {
+        if (!this.config.enabled) {
+            return { sent: false, reason: 'disabled' };
+        }
+
+        const missingConfig = this.getMissingConfig();
+        if (missingConfig.length > 0) {
+            throw new Error(`Missing report email config: ${missingConfig.join(', ')}`);
+        }
+
+        const transporter = await this.getTransporter();
+        const report = this.safeCall(this.getStatusReport, {});
+        const backgroundStats = this.safeCall(this.getBackgroundStats, null);
+        const cameraStats = this.safeCall(this.getCameraStats, null);
+
+        const generatedAt = new Date();
+        const subjectDate = generatedAt.toISOString().slice(0, 10);
+        const subject = `${this.config.subjectPrefix} - ${subjectDate}`;
+
+        const text = this.buildReportText({
+            generatedAt,
+            trigger,
+            context,
+            report,
+            backgroundStats,
+            cameraStats
+        });
+
+        const message = await transporter.sendMail({
+            from: this.config.from,
+            to: this.parseRecipients(this.config.to).join(','),
+            subject,
+            text
+        });
+
+        console.log(`✓ Report email sent (${trigger}) to ${this.config.to} [${message.messageId}]`);
+
+        return {
+            sent: true,
+            messageId: message.messageId
+        };
+    }
+
+    async sendLifecycleNotification(eventName, details = {}) {
+        const trigger = `lifecycle:${eventName}`;
+        return this.sendReportEmailWithContext(trigger, {
+            eventName,
+            ...details
+        });
+    }
+
+    async sendShutdownNotification(details = {}) {
+        if (!this.config.enabled || !this.config.notifyOnShutdown) {
+            return { sent: false, reason: 'shutdown_notification_disabled' };
+        }
+
+        return this.sendLifecycleNotification('shutdown', details);
+    }
+
+    safeCall(fn, fallback) {
+        try {
+            return fn();
+        } catch (error) {
+            console.warn(`⚠️  Report email data source failed: ${error.message}`);
+            return fallback;
+        }
+    }
+
+    getMissingConfig() {
+        const required = [
+            ['REPORT_EMAIL_SMTP_HOST', this.config.smtpHost],
+            ['REPORT_EMAIL_SMTP_PORT', Number.isFinite(this.config.smtpPort)],
+            ['REPORT_EMAIL_SMTP_USER', this.config.smtpUser],
+            ['REPORT_EMAIL_SMTP_PASS', this.config.smtpPass],
+            ['REPORT_EMAIL_TO', this.config.to],
+            ['REPORT_EMAIL_FROM', this.config.from]
+        ];
+
+        return required
+            .filter(([, value]) => !value)
+            .map(([name]) => name);
+    }
+
+    parseRecipients(value) {
+        return String(value)
+            .split(',')
+            .map((recipient) => recipient.trim())
+            .filter(Boolean);
+    }
+
+    async getTransporter() {
+        if (this.transporter) {
+            return this.transporter;
+        }
+
+        let nodemailerModule;
+        try {
+            nodemailerModule = await import('nodemailer');
+        } catch (error) {
+            throw new Error('nodemailer dependency is missing. Run npm install to enable report emails.');
+        }
+
+        const nodemailer = nodemailerModule.default || nodemailerModule;
+
+        this.transporter = nodemailer.createTransport({
+            host: this.config.smtpHost,
+            port: this.config.smtpPort,
+            secure: this.config.smtpSecure,
+            auth: {
+                user: this.config.smtpUser,
+                pass: this.config.smtpPass
+            }
+        });
+
+        await this.transporter.verify();
+        return this.transporter;
+    }
+
+    buildReportText({ generatedAt, trigger, context, report, backgroundStats, cameraStats }) {
+        const lines = [
+            'BasinWx Monitoring Report',
+            `Generated: ${generatedAt.toISOString()}`,
+            `Trigger: ${trigger}`,
+            ''
+        ];
+
+        const contextEntries = Object.entries(context || {})
+            .filter(([, value]) => value !== undefined && value !== null && value !== '');
+
+        if (contextEntries.length > 0) {
+            lines.push('Event Context');
+            contextEntries.forEach(([key, value]) => {
+                const formattedValue = value instanceof Error
+                    ? (value.stack || value.message)
+                    : String(value);
+
+                lines.push(`- ${key}: ${formattedValue}`);
+            });
+            lines.push('');
+        }
+
+        const summary = report?.summary || {};
+        lines.push('Summary');
+        lines.push(`- Overall Health: ${summary.overallHealth || 'unknown'}`);
+        lines.push(`- Data Types Monitored: ${summary.dataTypesMonitored || 0}`);
+        lines.push(`- Last Check: ${summary.lastCheck || 'unknown'}`);
+
+        const issues = Array.isArray(summary.issues) ? summary.issues : [];
+        lines.push(`- Issues: ${issues.length > 0 ? issues.join('; ') : 'none'}`);
+        lines.push('');
+
+        const freshnessEntries = Object.entries(report?.dataFreshness || {});
+        lines.push('Data Freshness');
+        if (freshnessEntries.length === 0) {
+            lines.push('- No freshness data available');
+        } else {
+            freshnessEntries.forEach(([dataType, data]) => {
+                const status = data?.status || 'unknown';
+                const age = Number.isFinite(data?.ageMinutes) ? `${data.ageMinutes} min old` : 'age unknown';
+                const latest = data?.latestFile ? `latest=${data.latestFile}` : '';
+                lines.push(`- ${dataType}: ${status} (${age}) ${latest}`.trim());
+            });
+        }
+        lines.push('');
+
+        if (backgroundStats) {
+            lines.push('Background Refresh');
+            lines.push(`- Service Status: ${backgroundStats.isRunning ? 'running' : 'stopped'}`);
+            lines.push(`- Essential Refresh Count: ${backgroundStats.refreshCount?.essential ?? 'n/a'}`);
+            lines.push(`- Frequent Refresh Count: ${backgroundStats.refreshCount?.frequent ?? 'n/a'}`);
+            lines.push(`- Infrequent Refresh Count: ${backgroundStats.refreshCount?.infrequent ?? 'n/a'}`);
+            lines.push(`- Estimated API Calls/Minute: ${backgroundStats.estimatedApiCallsPerMinute ?? 'n/a'}`);
+            lines.push('');
+        }
+
+        if (cameraStats) {
+            lines.push('Camera Analysis Scheduler');
+            lines.push(`- Running: ${cameraStats.isRunning ? 'yes' : 'no'}`);
+            lines.push(`- Camera Queue: ${cameraStats.cameraQueue ?? 'n/a'}`);
+            lines.push(`- Cached Cameras: ${cameraStats.cachedCameras ?? 'n/a'}`);
+            lines.push(`- Cache Hit Rate: ${cameraStats.cacheHitRate ?? 'n/a'}`);
+            lines.push(`- Total Analyses: ${cameraStats.totalAnalyses ?? 'n/a'}`);
+            lines.push(`- Failed Analyses: ${cameraStats.failedAnalyses ?? 'n/a'}`);
+            lines.push(`- Last Analysis Time: ${cameraStats.lastAnalysisTime || 'n/a'}`);
+            if (cameraStats.warmRestore) {
+                lines.push(`- Warm Restore Count: ${cameraStats.warmRestore.restoredDetectionsCount ?? 0}`);
+                lines.push(`- Warm Restore Snapshot Age: ${cameraStats.warmRestore.restoredSnapshotAgeMinutes ?? 'n/a'} min`);
+                lines.push(`- Warm Restored From Disk: ${cameraStats.warmRestore.restoredFromDisk ? 'yes' : 'no'}`);
+            }
+            lines.push('');
+        }
+
+        const alerts = Array.isArray(report?.alerts) ? report.alerts.slice(-10) : [];
+        lines.push('Recent Alerts');
+        if (alerts.length === 0) {
+            lines.push('- None');
+        } else {
+            alerts.forEach((alert) => {
+                lines.push(`- [${alert.level || 'info'}] ${alert.message || 'No message'} (${alert.timestamp || 'unknown time'})`);
+            });
+        }
+        lines.push('');
+        lines.push('Generated automatically by BasinWx report email service.');
+
+        return lines.join('\n');
+    }
+}
+
+export default ReportEmailService;

--- a/server/routes/roadWeather.js
+++ b/server/routes/roadWeather.js
@@ -24,6 +24,38 @@ router.get('/road-weather', async (req, res) => {
     }
 });
 
+router.get('/road-weather/camera-scheduler-status', (req, res) => {
+    try {
+        const scheduler = roadWeatherService.cameraAnalysisScheduler;
+        if (!scheduler) {
+            return res.status(503).json({
+                success: false,
+                error: 'Camera analysis scheduler is not available'
+            });
+        }
+
+        const stats = scheduler.getStats();
+
+        res.json({
+            success: true,
+            timestamp: new Date().toISOString(),
+            warmRestore: {
+                restoredDetectionsCount: stats.warmRestore?.restoredDetectionsCount ?? 0,
+                restoredSnapshotAgeMinutes: stats.warmRestore?.restoredSnapshotAgeMinutes ?? null,
+                restoredFromDisk: stats.warmRestore?.restoredFromDisk ?? false
+            },
+            scheduler: stats
+        });
+    } catch (error) {
+        console.error('Error fetching camera scheduler status:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to fetch camera scheduler status',
+            message: error.message
+        });
+    }
+});
+
 // Removed unused /road-weather/conditions endpoint
 
 // Removed unused /road-weather/nws/:lat/:lon endpoint

--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,8 @@ import trafficEventsRoutes from './routes/trafficEvents.js';
 import synopticAPIRoutes from './routes/synopticAPI.js';
 import BackgroundRefreshService from './backgroundRefresh.js';
 import analyticsMiddleware, { getAnalyticsStats } from './middleware/analytics.js';
+import { getMonitor } from './monitoring/dataMonitor.js';
+import ReportEmailService from './reportEmailService.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -21,6 +23,11 @@ const __dirname = path.dirname(__filename);
 
 // Initialize background refresh service (includes camera analysis scheduler)
 const backgroundRefresh = new BackgroundRefreshService();
+const reportEmailService = new ReportEmailService({
+    getStatusReport: () => getMonitor().getStatusReport(),
+    getBackgroundStats: () => backgroundRefresh.getStats(),
+    getCameraStats: () => backgroundRefresh.cameraAnalysisScheduler.getStats()
+});
 
 // Share the roadWeatherService instance with routes
 // This ensures all routes use the same instance with camera analysis scheduler
@@ -188,6 +195,76 @@ server.listen(PORT, () => {
 
     // Start background UDOT API refresh
     backgroundRefresh.start();
+    reportEmailService.start();
+});
+
+let isShuttingDown = false;
+const shutdown = async (signal, options = {}) => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+
+    console.log(`\nReceived ${signal}. Shutting down services...`);
+
+    const shutdownContext = {
+        signal,
+        reason: options.reason || 'graceful_shutdown',
+        pid: process.pid,
+        uptimeSeconds: Math.round(process.uptime()),
+        exitCode: options.exitCode ?? 0
+    };
+
+    if (options.error) {
+        shutdownContext.error = options.error.stack || options.error.message || String(options.error);
+    }
+
+    try {
+        await Promise.race([
+            reportEmailService.sendShutdownNotification(shutdownContext),
+            new Promise((resolve) => setTimeout(resolve, 4000))
+        ]);
+    } catch (error) {
+        console.error(`Failed to send shutdown report email: ${error.message}`);
+    }
+
+    reportEmailService.stop();
+    backgroundRefresh.stop();
+
+    server.close(() => {
+        console.log('Server shutdown complete');
+        process.exit(options.exitCode ?? 0);
+    });
+
+    setTimeout(() => {
+        console.error('Forced shutdown after timeout');
+        process.exit(1);
+    }, 10000).unref();
+};
+
+process.on('SIGINT', () => {
+    void shutdown('SIGINT', { reason: 'interrupt_signal', exitCode: 0 });
+});
+
+process.on('SIGTERM', () => {
+    void shutdown('SIGTERM', { reason: 'terminate_signal', exitCode: 0 });
+});
+
+process.on('uncaughtException', (error) => {
+    console.error('Uncaught exception:', error);
+    void shutdown('uncaughtException', {
+        reason: 'uncaught_exception',
+        error,
+        exitCode: 1
+    });
+});
+
+process.on('unhandledRejection', (reason) => {
+    const rejectionError = reason instanceof Error ? reason : new Error(String(reason));
+    console.error('Unhandled rejection:', rejectionError);
+    void shutdown('unhandledRejection', {
+        reason: 'unhandled_rejection',
+        error: rejectionError,
+        exitCode: 1
+    });
 });
 
 // Error handling middleware


### PR DESCRIPTION
This PR fixes gray camera rings after server restarts by restoring cached camera detections from disk on startup.

What changed

- Persist and restore camera detections across restarts
- Use dynamic cache TTL based on full camera rotation time
- Add warm-restore status metrics and endpoint: /api/road-weather/camera-scheduler-status
- Add optional startup/shutdown report emails (SMTP via env vars)
- Update docs and scheduler tests