### PR TITLE
Fix vis=0 falsy bug in legacy roads.js

### DIFF
--- a/public/js/roads.legacy.js
+++ b/public/js/roads.legacy.js
@@ -1068,7 +1068,7 @@ function updateConditionCardsWithLocation(locationData) {
     const visCard = document.querySelector('.condition-card-compact.visibility .value');
     if (visCard) {
         const vis = locationData.visibility;
-        if (vis && vis > 0) {
+        if (vis !== null && vis !== undefined && vis >= 0) {
             const maxVis = unitsSystem.isMetric ? 16 : 10; // 16 km ≈ 10 mi
             visCard.textContent = vis > maxVis ? `${maxVis}+ ${unitsSystem.getVisibilityUnit()}` : unitsSystem.formatVisibility(vis);
         } else {


### PR DESCRIPTION
When visibility is exactly 0 (fog/blizzard), the check `if (vis && vis > 0)` treated it as missing data since 0 is falsy in JavaScript. Use explicit null/undefined checks with `>= 0` instead.

Fixes #145