### PR TITLE
feat: make operational core agnostic across .com/.dev servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@
 # ── Server Configuration ─────────────────────────────────────────────
 NODE_ENV=development                            # [per-server] production on ops, development on dev
 PORT=3000                                       # [per-server] 3000 on ops, 3001 on dev (free up 3000 for hot-swap testing)
-APP_URL=https://www.basinwx.dev                 # [per-server] public URL this deployment serves
 
 # ── Data Upload API (CHPC → website) ─────────────────────────────────
 # Generate a fresh key per server with: node scripts/generate-api-key.js

--- a/.env.example
+++ b/.env.example
@@ -1,31 +1,58 @@
 # Environment Variables Template
-# Copy this file to .env and fill in your actual values
-# DO NOT commit .env files to git - they should remain local only
+# Copy this file to .env and fill in your actual values.
+# DO NOT commit .env files to git — they are gitignored.
+# After populating, lock down permissions:    chmod 600 .env
+#
+# Variables are grouped by: [per-server] = differs between basinwx.com/.dev boxes,
+#                           [shared]     = same across both boxes,
+#                           [optional]   = has a safe default.
 
-# Server Configuration
-PORT=3000
+# ── Server Configuration ─────────────────────────────────────────────
+NODE_ENV=development                            # [per-server] production on ops, development on dev
+PORT=3000                                       # [per-server] 3000 on ops, 3001 on dev (free up 3000 for hot-swap testing)
+APP_URL=https://www.basinwx.dev                 # [per-server] public URL this deployment serves
 
-# Data Upload API (for CHPC server uploads)
-# Generate using: node scripts/generate-api-key.js
+# ── Data Upload API (CHPC → website) ─────────────────────────────────
+# Generate a fresh key per server with: node scripts/generate-api-key.js
+# Same key can be shared between .com and .dev if you want the same CHPC job to upload to both.
 DATA_UPLOAD_API_KEY=your_generated_api_key_here
 
-# UDoT Traffic API (for road weather and traffic data)
-# Obtain from UDoT: https://www.udottraffic.utah.gov/
-UDOT_API_KEY=your_udot_api_key_here
+# ── Upstream data APIs ───────────────────────────────────────────────
+UDOT_API_KEY=your_udot_api_key_here             # [shared]   https://www.udottraffic.utah.gov/
+SYNOPTIC_API_TOKEN=your_synoptic_token_here     # [shared]   https://synoptic.utah.edu/
+# SYNOPTIC_API_KEY=                             # [optional] alias — code accepts either KEY or TOKEN
 
-# Synoptic Weather API (for weather station data)
-# Obtain from: https://synoptic.utah.edu/
-SYNOPTIC_API_TOKEN=your_synoptic_token_here
+# BASE_URL=http://localhost:3000                # [optional] only used by scripts/test-api.js in local dev
 
-# Website Upload API (for Python scripts on CHPC)
-# This should match DATA_UPLOAD_API_KEY above
-BASINWX_API_KEY=your_generated_api_key_here
+# ── CHPC-side uploader (lives in CHPC env, not here; documented for reference) ──
+# BASINWX_API_KEY should match DATA_UPLOAD_API_KEY on the destination server(s).
+# BASINWX_API_URLS is a comma-separated fan-out list. First URL is primary (failure fails the job);
+# remaining URLs are best-effort mirrors (failures log WARN but do not fail the job).
+# Example on CHPC:
+#   BASINWX_API_URLS="https://basinwx.com,https://basinwx.dev"
+#   BASINWX_API_KEY="..."
 
-# Camera Scheduler Tuning (optional — defaults are tuned for 72% UDOT rate usage)
-# Lower interval = fresher data but higher API usage (600 calls/hr limit)
-# At 25s: ~432 calls/hr (72%). At 30s: ~360 calls/hr (60%).
-CAMERA_INTERVAL_SECONDS=25
-# Padding multiplier on rotation time for cache TTL (1.05 = 5% headroom)
-CAMERA_CACHE_PADDING=1.05
-# Random jitter range in seconds added per cycle to smooth request pattern
-CAMERA_JITTER_SECONDS=4
+# ── Camera scheduler (optional, tuned for UDOT 600 calls/hr rate limit) ──
+CAMERA_INTERVAL_SECONDS=25                      # [optional] 25s → ~432 calls/hr (72%); 30s → 60%
+CAMERA_CACHE_PADDING=1.05                       # [optional] cache TTL headroom multiplier
+CAMERA_JITTER_SECONDS=4                         # [optional] random jitter to smooth request pattern
+# CAMERA_BATCH_SIZE=                            # [optional] override batch size
+# CAMERA_MAX_RETRIES=                           # [optional] override retry count
+
+# ── Report email service (optional; disabled by default) ─────────────
+# Set REPORT_EMAIL_ENABLED=true to activate. All REPORT_EMAIL_* vars are read by server/reportEmailService.js.
+REPORT_EMAIL_ENABLED=false
+REPORT_EMAIL_SMTP_HOST=
+REPORT_EMAIL_SMTP_PORT=587
+REPORT_EMAIL_SMTP_SECURE=false
+REPORT_EMAIL_SMTP_USER=
+REPORT_EMAIL_SMTP_PASS=
+REPORT_EMAIL_FROM=
+REPORT_EMAIL_TO=
+REPORT_EMAIL_SCHEDULE_ENABLED=false
+REPORT_EMAIL_CRON=0 8 * * *
+REPORT_EMAIL_TIMEZONE=America/Denver
+REPORT_EMAIL_SEND_ON_STARTUP=true
+REPORT_EMAIL_NOTIFY_ON_SHUTDOWN=true
+REPORT_EMAIL_SUBJECT_PREFIX=BasinWx Status Report
+# REPORT_EMAIL_NOTIFY_ON_STARTUP=              # [optional] legacy alias for SEND_ON_STARTUP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,12 @@ The operational core must be agnostic to which server / branch it runs on.
 - A third developer laptop/VM may also run this repo. It is **not operational**, may have broken paths, and must never be the source of truth.
 - Full bring-up runbook, nginx template, cert renewal, and "did this work?" sanity checklist live in `docs/DEPLOYMENT.md`.
 
+### Bring-up lessons learnt (keep for future re-provisioning)
+- **Linode Cloud Firewall defaults to Drop.** A fresh linode blocks 80/443 until you explicitly accept them. Symptoms: `certbot renew --dry-run` times out on the ACME challenge, site is unreachable externally, but internal `curl -I http://127.0.0.1:${PORT}` works fine. Check each box's firewall rules in the Linode console before assuming nginx or certbot are broken.
+- **Don't use `certbot --manual` for these domains.** Its renewal config writes `authenticator = manual`, which the systemd timer cannot drive non-interactively — the cert silently fails to renew until it expires. Always use `certbot certonly --nginx` (or `--webroot`) so renewal is automated. Verify with `sudo certbot renew --dry-run`.
+- **`.dev` TLDs trip some client networks.** HSTS-preload plus occasional SNI-based filtering on corporate/campus/ISP routers produces "connection reset" errors that look like the server is down. Always phone-tether test (`curl -I https://www.basinwx.dev/` on a mobile hotspot) before blaming the server; if it works on cellular, the site is fine and the user's LAN is the culprit.
+- **`pm2 startup` is not optional.** Without the systemd unit a reboot silently loses the site. Confirm with `systemctl list-unit-files | grep pm2`.
+
 ## Data Pipeline
 **CHPC (compute server)** → **POST /api/upload/:dataType** → **both `www.basinwx.com` and `www.basinwx.dev`**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,14 +3,28 @@
 ## Project Overview
 Weather data visualization website showing live air quality observations and forecasts for Uintah Basin region.
 
+## Deployment Topology
+The operational core must be agnostic to which server / branch it runs on.
+
+| Role | Branch | Domain | pm2 app name |
+|---|---|---|---|
+| Production | `ops` | `www.basinwx.com` | `basinwx-ops` |
+| Rehearsal mirror | `dev` | `www.basinwx.dev` | `basinwx-dev` |
+
+- Both boxes: Linode, repo at `/srv/ubair-website`, pm2 run as the `deploy` user, nginx reverse proxy, Let's Encrypt certs.
+- pm2 app name is derived from `git rev-parse --abbrev-ref HEAD` (see `ecosystem.config.cjs`), so whichever branch is checked out dictates the running app identity.
+- `www.basinwx.dev` receives the same CHPC data as `.com` (fan-out upload) and runs whichever branch is checked out, so merging a PR into `dev` is a real-world dry-run before promotion to `ops`. It is also where stakeholder demos happen.
+- A third developer laptop/VM may also run this repo. It is **not operational**, may have broken paths, and must never be the source of truth.
+- Full bring-up runbook, nginx template, cert renewal, and "did this work?" sanity checklist live in `docs/DEPLOYMENT.md`.
+
 ## Data Pipeline
-**CHPC (compute server)** → **POST /api/upload/:dataType** → **Akamai (web server)**
+**CHPC (compute server)** → **POST /api/upload/:dataType** → **both `www.basinwx.com` and `www.basinwx.dev`**
 
 ### Data Flow
 1. **CHPC**: Python script using `brc-tools` pulls from Synoptic Weather API
 2. **Processing**: Data goes through polars/pandas → JSON format
-3. **Transfer**: Secure POST to `/api/upload/:dataType` with API key
-4. **Display**: Leaflet maps on Node.js website at basinwx.com
+3. **Transfer**: Secure POST to `/api/upload/:dataType` with API key, fanned out to every URL in `BASINWX_API_URLS` (first = primary, rest = best-effort mirrors)
+4. **Display**: Leaflet maps on Node.js website (live on `.com`, rehearsal on `.dev`)
 
 ### Data Types
 - **Live observations**: `map_obs_YYYYMMDD_HHMMZ.json` (geographic weather data)
@@ -46,7 +60,7 @@ Weather data visualization website showing live air quality observations and for
 ## Testing
 - **Development**: `npm run dev` (nodemon)
 - **API testing**: `npm run test-api` (automated script)
-- **Manual API test**: `POST localhost:3000/api/upload/observations`
+- **Manual API test**: `POST localhost:${PORT}/api/upload/observations` (PORT from `.env`; typically 3000 on ops, 3001 on dev)
 - **Example data**: Files in `/public/api/static/`
 
 ## Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,9 @@ The operational core must be agnostic to which server / branch it runs on.
 - **Real-time data**: Automatic refresh every 10 minutes
 
 ## Recent Updates
-- Removed all synthetic/demo data generation
-- Added comprehensive mobile responsiveness
+- **PR #178 (2026-04-22)**: operational-agnosticism pass — branch-derived pm2 app name, fan-out CHPC uploader (`BASINWX_API_URLS`), `docs/DEPLOYMENT.md` runbook, host-aware sidebar brand
 - Implemented 90s mode toggle with holographic background
 - Created data schema documentation (DATA_SCHEMA.md)
-- Added API testing script and SSL setup guide
 - Moved unused images to `/public/images/unused/`
 
 ## Secret Management
@@ -95,7 +93,6 @@ Environment variables are used for all API keys and sensitive configuration:
 **Never push directly to `dev`, `ops`, or `main`.**  All changes to these branches must go through a pull request. If you believe a direct push is warranted, ask the user to confirm — then ask a **second time** to be sure before proceeding. This applies to merges, reverts, version bumps, and any other commits.
 
 ## Team Notes
-- 4-person collaborative team
+- Small collaborative team (lead + RAs — see README for current roster)
 - CSS-HTML mapping: fire.css ↔ fire.html pattern
-- Clean codebase with minimal redundancy
 - 20-item improvement list available (IMPROVEMENTS.md)

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Real-time weather data visualization and air quality monitoring platform for the
 ## Technical Architecture
 
 ```
-CHPC (Data Processing) → API Upload → Akamai Server → Web Interface
+CHPC (Data Processing) → API Upload (fan-out) → Linode (.com ops + .dev rehearsal) → Web Interface
 ```
 
-- **Backend**: Node.js, Express.js
+- **Backend**: Node.js, Express.js, pm2
 - **Frontend**: Vanilla JavaScript, Leaflet, Plotly.js
 - **Data Pipeline**: Python (brc-tools), Synoptic Weather API
-- **Deployment**: Akamai CDN, SSL/TLS secured
+- **Deployment**: Two Linode boxes (`www.basinwx.com` ops, `www.basinwx.dev` rehearsal mirror), nginx reverse proxy, Let's Encrypt TLS
 
 ## Documentation --- still in flux and requiring review for AI slop
 
@@ -114,8 +114,11 @@ curl -s https://basinwx.com/api/live-observations | jq '.totalObservations'
 # How many forecast files?
 curl -s https://basinwx.com/api/filelist/forecasts | jq 'length'
 
-# Akamai server logs
-ssh akamai "pm2 logs --lines 50"
+# Server logs (ops box)
+ssh deploy@www.basinwx.com "pm2 logs --lines 50"
+
+# Server logs (dev / rehearsal box)
+ssh deploy@www.basinwx.dev "pm2 logs --lines 50"
 ```
 
 ### Automated Email Report

--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ EOF
 chmod +x .git/hooks/post-merge
 ```
 
+### "Is the site actually down?" — triage in order
+Before escalating, rule out the easy causes. The server has been guilty only ~half the time during bring-up.
+
+```bash
+# From your laptop
+curl -I https://www.basinwx.dev/          # expect HTTP/2 200
+curl -I https://www.basinwx.com/          # expect HTTP/2 200
+```
+
+If either RSTs or times out, tether your laptop to your phone's hotspot and retry the same curl. Cellular working but wifi not = your current network (campus/office/ISP) is SNI-filtering `.dev` (HSTS-preloaded, new-TLD-suspicious) or has a stale resolver cache. The server is fine; clear your browser's HSTS+DNS cache or work from a different network.
+
+If cellular also fails, it's the server. SSH in and walk the "did this work?" checklist in `docs/DEPLOYMENT.md` §6 (branch, pm2, systemd unit, `.env` perms, internal curl, nginx config, 80/443 listening, cert expiry, external curl, pm2 logs). Known landmines picked up during first-time bring-up: **Linode Cloud Firewall defaults to Drop** (80/443 must be explicitly accepted per box); **`certbot --manual` breaks auto-renewal** — use `--nginx` or `--webroot`.
+
 ### Data Troubleshooting
 ```bash
 # Clyfar's Herbie cache (not default ~/.cache/herbie)

--- a/chpc-deployment/DEPLOYMENT_GUIDE.md
+++ b/chpc-deployment/DEPLOYMENT_GUIDE.md
@@ -90,7 +90,7 @@ Verify they're set:
 
 ```bash
 echo $DATA_UPLOAD_API_KEY
-echo $BASINWX_API_URL
+echo $BASINWX_API_URLS
 ```
 
 You should see:
@@ -114,7 +114,7 @@ bash test_upload.sh
 ```
 Test 1: Environment Check
 ✓ DATA_UPLOAD_API_KEY set
-✓ BASINWX_API_URL: https://basinwx.com
+✓ BASINWX_API_URLS: https://basinwx.com
 ✓ Python package: requests
 ✓ Python package: jsonschema
 

--- a/chpc-deployment/README.md
+++ b/chpc-deployment/README.md
@@ -179,7 +179,7 @@ Cron Job (every 10 min)            Website displays on live map
 ```bash
 # Required
 export DATA_UPLOAD_API_KEY="48cd2f722c19af756e7443230efe9fcc"
-export BASINWX_API_URL="https://basinwx.com"
+export BASINWX_API_URLS="https://basinwx.com"
 ```
 
 **⚠️ Note:** Use `DATA_UPLOAD_API_KEY` (not `BASINWX_API_KEY`) to match brc-tools code.

--- a/chpc-deployment/ROLLBACK_PROCEDURE.md
+++ b/chpc-deployment/ROLLBACK_PROCEDURE.md
@@ -143,7 +143,7 @@ vim ~/.bashrc  # or nano ~/.bashrc
 
 # Find and remove these lines:
 # export DATA_UPLOAD_API_KEY="..."
-# export BASINWX_API_URL="..."
+# export BASINWX_API_URLS="..."
 
 # Save and exit
 
@@ -212,7 +212,7 @@ crontab -l
 vim ~/.bashrc
 # Delete lines:
 #   export DATA_UPLOAD_API_KEY="..."
-#   export BASINWX_API_URL="..."
+#   export BASINWX_API_URLS="..."
 source ~/.bashrc
 
 # Remove config directory
@@ -256,7 +256,7 @@ mv ~/chpc-deployment ~/chpc-deployment.old_$(date +%Y%m%d)
 crontab -l 2>&1 | grep "no crontab"
 
 # No environment variables
-echo $DATA_UPLOAD_API_KEY $BASINWX_API_URL
+echo $DATA_UPLOAD_API_KEY $BASINWX_API_URLS
 # (Both empty)
 
 # No config files

--- a/chpc-deployment/TESTING_CHECKLIST.md
+++ b/chpc-deployment/TESTING_CHECKLIST.md
@@ -19,10 +19,10 @@
 ### 1.1 Environment Variables
 ```bash
 echo $DATA_UPLOAD_API_KEY
-echo $BASINWX_API_URL
+echo $BASINWX_API_URLS
 ```
 - [ ] `DATA_UPLOAD_API_KEY` shows `48cd2f722c19af756e7443230efe9fcc`
-- [ ] `BASINWX_API_URL` shows `https://basinwx.com`
+- [ ] `BASINWX_API_URLS` shows `https://basinwx.com`
 
 ### 1.2 Configuration Files
 ```bash
@@ -189,7 +189,7 @@ echo $DATA_UPLOAD_API_KEY  # Verify it's correct again
 
 ### 5.2 Test with Unreachable Server
 ```bash
-export BASINWX_API_URL="https://invalid-server-for-testing.com"
+export BASINWX_API_URLS="https://invalid-server-for-testing.com"
 cd ~/brc-tools
 python3 brc_tools/download/get_map_obs.py 2>&1 | tail -20
 ```

--- a/chpc-deployment/setup_chpc_env.sh
+++ b/chpc-deployment/setup_chpc_env.sh
@@ -22,9 +22,10 @@ echo ""
 # IMPORTANT: Use DATA_UPLOAD_API_KEY to match brc-tools code.
 # BASINWX_API_URLS is a comma-separated fan-out list. The first URL is the
 # primary destination (its failure fails the job); remaining URLs are
-# best-effort mirrors.
+# best-effort mirrors. No default — an operator must opt in explicitly so we
+# never silently upload to production.
 : "${DATA_UPLOAD_API_KEY:=}"
-: "${BASINWX_API_URLS:=https://basinwx.com,https://basinwx.dev}"
+: "${BASINWX_API_URLS:=}"
 
 if [ -z "$DATA_UPLOAD_API_KEY" ]; then
     read -r -s -p "DATA_UPLOAD_API_KEY (input hidden): " DATA_UPLOAD_API_KEY
@@ -32,6 +33,21 @@ if [ -z "$DATA_UPLOAD_API_KEY" ]; then
 fi
 if [ -z "$DATA_UPLOAD_API_KEY" ]; then
     echo "ERROR: DATA_UPLOAD_API_KEY must be set. Aborting." >&2
+    exit 1
+fi
+
+if [ -z "$BASINWX_API_URLS" ]; then
+    echo ""
+    echo "BASINWX_API_URLS is a comma-separated fan-out list."
+    echo "  First URL = primary (failure fails the job)."
+    echo "  Remaining URLs = best-effort mirrors."
+    echo "Examples:"
+    echo "  https://basinwx.dev                           (dev only, safe)"
+    echo "  https://basinwx.com,https://basinwx.dev       (full production fan-out)"
+    read -r -p "BASINWX_API_URLS: " BASINWX_API_URLS
+fi
+if [ -z "$BASINWX_API_URLS" ]; then
+    echo "ERROR: BASINWX_API_URLS must be set. Aborting." >&2
     exit 1
 fi
 
@@ -77,18 +93,27 @@ echo ""
 
 echo "Step 4: Setting up environment variables..."
 
-# Create/update .bashrc entry
+# Create/update .bashrc entries. Each export is checked independently so a
+# partially-migrated .bashrc (e.g. has DATA_UPLOAD_API_KEY from the old script
+# but not BASINWX_API_URLS) gets fully updated on re-run.
 BASHRC="$HOME/.bashrc"
-if ! grep -q "DATA_UPLOAD_API_KEY" "$BASHRC" 2>/dev/null; then
+add_bashrc_export() {
+    local var="$1" value="$2"
+    if ! grep -q "^export ${var}=" "$BASHRC" 2>/dev/null; then
+        echo "export ${var}=\"${value}\"" >> "$BASHRC"
+        echo "  + added export $var to $BASHRC"
+    else
+        echo "  ✓ export $var already present in $BASHRC"
+    fi
+}
+
+if ! grep -q "# BasinWx Data Pipeline Configuration" "$BASHRC" 2>/dev/null; then
     echo "" >> "$BASHRC"
     echo "# BasinWx Data Pipeline Configuration" >> "$BASHRC"
-    echo "export DATA_UPLOAD_API_KEY=\"$DATA_UPLOAD_API_KEY\"" >> "$BASHRC"
-    echo "export BASINWX_API_KEY=\"\$DATA_UPLOAD_API_KEY\"" >> "$BASHRC"
-    echo "export BASINWX_API_URLS=\"$BASINWX_API_URLS\"" >> "$BASHRC"
-    echo "✓ Added to $BASHRC"
-else
-    echo "✓ Already exists in $BASHRC (verify BASINWX_API_URLS is set there too)"
 fi
+add_bashrc_export DATA_UPLOAD_API_KEY "$DATA_UPLOAD_API_KEY"
+add_bashrc_export BASINWX_API_KEY "\$DATA_UPLOAD_API_KEY"
+add_bashrc_export BASINWX_API_URLS "$BASINWX_API_URLS"
 
 # Export for current session
 export DATA_UPLOAD_API_KEY="$DATA_UPLOAD_API_KEY"
@@ -97,9 +122,15 @@ export BASINWX_API_URLS="$BASINWX_API_URLS"
 echo "✓ Exported for current session"
 echo ""
 
-echo "Step 5: Creating website URL config file..."
+echo "Step 5: Creating website URL config files..."
 echo "$BASINWX_API_URLS" > "$CONFIG_DIR/website_urls"
 echo "✓ Created: $CONFIG_DIR/website_urls"
+# Back-compat: legacy brc-tools helpers read ~/.config/ubair-website/website_url
+# (singular). Write the primary URL there so old callers keep working until
+# they're migrated.
+PRIMARY_URL_FOR_FILE="${BASINWX_API_URLS%%,*}"
+echo "$PRIMARY_URL_FOR_FILE" > "$CONFIG_DIR/website_url"
+echo "✓ Created: $CONFIG_DIR/website_url (legacy single-URL file, primary only)"
 echo ""
 
 echo "Step 6: Creating log directory..."

--- a/chpc-deployment/setup_chpc_env.sh
+++ b/chpc-deployment/setup_chpc_env.sh
@@ -15,9 +15,26 @@ echo "=========================================="
 echo ""
 
 # Configuration
-# IMPORTANT: Use DATA_UPLOAD_API_KEY to match brc-tools code
-DATA_UPLOAD_API_KEY="48cd2f722c19af756e7443230efe9fcc"
-BASINWX_API_URL="https://basinwx.com"
+#
+# Secrets are NEVER hardcoded in this script. Populate them in your shell
+# environment before running (or accept the prompts below).
+#
+# IMPORTANT: Use DATA_UPLOAD_API_KEY to match brc-tools code.
+# BASINWX_API_URLS is a comma-separated fan-out list. The first URL is the
+# primary destination (its failure fails the job); remaining URLs are
+# best-effort mirrors.
+: "${DATA_UPLOAD_API_KEY:=}"
+: "${BASINWX_API_URLS:=https://basinwx.com,https://basinwx.dev}"
+
+if [ -z "$DATA_UPLOAD_API_KEY" ]; then
+    read -r -s -p "DATA_UPLOAD_API_KEY (input hidden): " DATA_UPLOAD_API_KEY
+    echo ""
+fi
+if [ -z "$DATA_UPLOAD_API_KEY" ]; then
+    echo "ERROR: DATA_UPLOAD_API_KEY must be set. Aborting." >&2
+    exit 1
+fi
+
 CONFIG_DIR="$HOME/.config/ubair-website"
 BRC_TOOLS_DIR="$HOME/gits/brc-tools"  # Adjust if different
 
@@ -66,21 +83,23 @@ if ! grep -q "DATA_UPLOAD_API_KEY" "$BASHRC" 2>/dev/null; then
     echo "" >> "$BASHRC"
     echo "# BasinWx Data Pipeline Configuration" >> "$BASHRC"
     echo "export DATA_UPLOAD_API_KEY=\"$DATA_UPLOAD_API_KEY\"" >> "$BASHRC"
-    echo "export BASINWX_API_URL=\"$BASINWX_API_URL\"" >> "$BASHRC"
+    echo "export BASINWX_API_KEY=\"\$DATA_UPLOAD_API_KEY\"" >> "$BASHRC"
+    echo "export BASINWX_API_URLS=\"$BASINWX_API_URLS\"" >> "$BASHRC"
     echo "✓ Added to $BASHRC"
 else
-    echo "✓ Already exists in $BASHRC"
+    echo "✓ Already exists in $BASHRC (verify BASINWX_API_URLS is set there too)"
 fi
 
 # Export for current session
 export DATA_UPLOAD_API_KEY="$DATA_UPLOAD_API_KEY"
-export BASINWX_API_URL="$BASINWX_API_URL"
+export BASINWX_API_KEY="$DATA_UPLOAD_API_KEY"
+export BASINWX_API_URLS="$BASINWX_API_URLS"
 echo "✓ Exported for current session"
 echo ""
 
 echo "Step 5: Creating website URL config file..."
-echo "$BASINWX_API_URL" > "$CONFIG_DIR/website_url"
-echo "✓ Created: $CONFIG_DIR/website_url"
+echo "$BASINWX_API_URLS" > "$CONFIG_DIR/website_urls"
+echo "✓ Created: $CONFIG_DIR/website_urls"
 echo ""
 
 echo "Step 6: Creating log directory..."
@@ -110,21 +129,33 @@ else
 fi
 echo ""
 
-echo "Step 8: Testing API connectivity..."
-echo "Running health check..."
-if python3 -c "
-import os
-import requests
-api_key = os.environ.get('DATA_UPLOAD_API_KEY')
-api_url = os.environ.get('BASINWX_API_URL')
-response = requests.get(f'{api_url}/api/health', timeout=10)
-print(f'Status: {response.status_code}')
-print(f'Response: {response.text}')
+echo "Step 8: Testing API connectivity for every destination..."
+IFS=',' read -r -a URL_ARRAY <<< "$BASINWX_API_URLS"
+for i in "${!URL_ARRAY[@]}"; do
+    url="${URL_ARRAY[$i]}"
+    url="${url// /}"
+    role="mirror"
+    [ "$i" = "0" ] && role="primary"
+    echo "  [$role] $url"
+    if python3 -c "
+import requests, sys
+try:
+    r = requests.get('$url/api/health', timeout=10)
+    print(f'    Status: {r.status_code}')
+    sys.exit(0 if r.status_code == 200 else 1)
+except Exception as e:
+    print(f'    Error: {e}')
+    sys.exit(1)
 " 2>&1; then
-    echo "✓ Health check successful"
-else
-    echo -e "${YELLOW}Warning: Health check failed - server may be down or unreachable${NC}"
-fi
+        echo "  ✓ Reachable"
+    else
+        if [ "$role" = "primary" ]; then
+            echo -e "${RED}  ✗ Primary health check failed — CHPC uploads will fail${NC}"
+        else
+            echo -e "${YELLOW}  ⚠ Mirror health check failed — uploads will still attempt but log WARN${NC}"
+        fi
+    fi
+done
 echo ""
 
 echo "=========================================="
@@ -134,7 +165,7 @@ echo ""
 echo "Configuration saved to: $CONFIG_DIR"
 echo "Environment variables:"
 echo "  DATA_UPLOAD_API_KEY: ${DATA_UPLOAD_API_KEY:0:10}..."
-echo "  BASINWX_API_URL: $BASINWX_API_URL"
+echo "  BASINWX_API_URLS:    $BASINWX_API_URLS"
 echo ""
 echo "Next steps:"
 echo "1. Source your bashrc: source ~/.bashrc"

--- a/chpc-deployment/test_upload.sh
+++ b/chpc-deployment/test_upload.sh
@@ -25,7 +25,14 @@ TEST_DATA_DIR="$BRC_TOOLS_DIR/test_data"
 UPLOAD_SCRIPT="$BRC_TOOLS_DIR/brc_tools/download/push_data.py"
 
 # Fan-out destinations (first = primary, rest = best-effort mirrors).
-: "${BASINWX_API_URLS:=https://basinwx.com,https://basinwx.dev}"
+# No default — the test script must be explicit about which destination(s) it hits
+# so we never accidentally test-upload to production.
+if [ -z "${BASINWX_API_URLS:-}" ]; then
+    echo "ERROR: BASINWX_API_URLS must be set before running this script." >&2
+    echo "  Dev-only:        export BASINWX_API_URLS=https://basinwx.dev" >&2
+    echo "  Full fan-out:    export BASINWX_API_URLS=https://basinwx.com,https://basinwx.dev" >&2
+    exit 1
+fi
 PRIMARY_URL="${BASINWX_API_URLS%%,*}"
 MANIFEST_URL="${PRIMARY_URL}/DATA_MANIFEST.json"
 
@@ -112,10 +119,11 @@ echo ""
 echo -e "${BLUE}Test 3: API Health Check${NC}"
 echo "----------------------------------------"
 
-HEALTH_RESPONSE=$(python3 << EOF
-import requests
+HEALTH_RESPONSE=$(PRIMARY_URL="$PRIMARY_URL" python3 << 'EOF'
+import os, requests
+url = os.environ['PRIMARY_URL'] + '/api/health'
 try:
-    response = requests.get('${PRIMARY_URL}/api/health', timeout=10)
+    response = requests.get(url, timeout=10)
     print(f"STATUS:{response.status_code}")
     if response.status_code == 200:
         print(f"RESPONSE:{response.text}")

--- a/chpc-deployment/test_upload.sh
+++ b/chpc-deployment/test_upload.sh
@@ -23,7 +23,11 @@ NC='\033[0m'
 BRC_TOOLS_DIR="$HOME/brc-tools"
 TEST_DATA_DIR="$BRC_TOOLS_DIR/test_data"
 UPLOAD_SCRIPT="$BRC_TOOLS_DIR/brc_tools/download/push_data.py"
-MANIFEST_URL="https://basinwx.com/DATA_MANIFEST.json"
+
+# Fan-out destinations (first = primary, rest = best-effort mirrors).
+: "${BASINWX_API_URLS:=https://basinwx.com,https://basinwx.dev}"
+PRIMARY_URL="${BASINWX_API_URLS%%,*}"
+MANIFEST_URL="${PRIMARY_URL}/DATA_MANIFEST.json"
 
 echo ""
 echo "=========================================="
@@ -58,11 +62,14 @@ else
     echo -e "${GREEN}✓ DATA_UPLOAD_API_KEY set${NC} (${DATA_UPLOAD_API_KEY:0:10}...)"
 fi
 
-if [ -z "$BASINWX_API_URL" ]; then
-    echo -e "${YELLOW}⚠ BASINWX_API_URL not set, using default${NC}"
-    export BASINWX_API_URL="https://basinwx.com"
-fi
-echo -e "${GREEN}✓ BASINWX_API_URL${NC}: $BASINWX_API_URL"
+echo -e "${GREEN}✓ BASINWX_API_URLS${NC}: $BASINWX_API_URLS"
+echo "  primary: $PRIMARY_URL"
+IFS=',' read -r -a _URL_ARRAY <<< "$BASINWX_API_URLS"
+for i in "${!_URL_ARRAY[@]}"; do
+    [ "$i" = "0" ] && continue
+    echo "  mirror:  ${_URL_ARRAY[$i]// /}"
+done
+export BASINWX_API_URLS
 
 # Check Python packages
 for package in requests jsonschema; do
@@ -81,14 +88,23 @@ echo ""
 echo -e "${BLUE}Test 2: Network Connectivity${NC}"
 echo "----------------------------------------"
 
-echo "Testing connection to $BASINWX_API_URL..."
-if curl -s --connect-timeout 10 "$BASINWX_API_URL" > /dev/null; then
-    echo -e "${GREEN}✓ Website reachable${NC}"
+echo "Testing connection to $PRIMARY_URL (primary)..."
+if curl -s --connect-timeout 10 "$PRIMARY_URL" > /dev/null; then
+    echo -e "${GREEN}✓ Primary reachable${NC}"
 else
-    echo -e "${RED}✗ Cannot reach website${NC}"
+    echo -e "${RED}✗ Cannot reach primary: $PRIMARY_URL${NC}"
     echo "  Check network/firewall settings"
     exit 1
 fi
+for i in "${!_URL_ARRAY[@]}"; do
+    [ "$i" = "0" ] && continue
+    mirror="${_URL_ARRAY[$i]// /}"
+    if curl -s --connect-timeout 10 "$mirror" > /dev/null; then
+        echo -e "${GREEN}✓ Mirror reachable${NC}: $mirror"
+    else
+        echo -e "${YELLOW}⚠ Mirror not reachable (uploads will log WARN): $mirror${NC}"
+    fi
+done
 
 echo ""
 
@@ -96,13 +112,10 @@ echo ""
 echo -e "${BLUE}Test 3: API Health Check${NC}"
 echo "----------------------------------------"
 
-HEALTH_RESPONSE=$(python3 << 'EOF'
-import os
+HEALTH_RESPONSE=$(python3 << EOF
 import requests
-import json
 try:
-    api_url = os.environ.get('BASINWX_API_URL', 'https://basinwx.com')
-    response = requests.get(f'{api_url}/api/health', timeout=10)
+    response = requests.get('${PRIMARY_URL}/api/health', timeout=10)
     print(f"STATUS:{response.status_code}")
     if response.status_code == 200:
         print(f"RESPONSE:{response.text}")
@@ -188,7 +201,7 @@ if [ -n "$SAMPLE_FILES" ]; then
     echo "Using test file: $(basename $TEST_FILE)"
     echo ""
 
-    echo "Running upload test..."
+    echo "Running fan-out upload test..."
     if python3 << EOF
 import os
 import sys
@@ -196,40 +209,58 @@ import requests
 import socket
 
 api_key = os.environ.get('DATA_UPLOAD_API_KEY')
-api_url = os.environ.get('BASINWX_API_URL', 'https://basinwx.com')
+api_urls = [u.strip().rstrip('/') for u in os.environ.get('BASINWX_API_URLS', '').split(',') if u.strip()]
 hostname = socket.gethostname()
 
-headers = {
-    'x-api-key': api_key,
-    'x-client-hostname': hostname
-}
+if not api_urls:
+    print('Error: BASINWX_API_URLS is empty')
+    sys.exit(1)
 
+headers = {'x-api-key': api_key, 'x-client-hostname': hostname}
 test_file = "$TEST_FILE"
+
+primary_ok = False
+mirror_failures = []
 with open(test_file, 'rb') as f:
-    files = {'file': (os.path.basename(test_file), f)}
+    payload_bytes = f.read()
+
+for idx, api_url in enumerate(api_urls):
+    role = 'PRIMARY' if idx == 0 else 'MIRROR'
+    print('=' * 60)
+    print(f'UPLOADING TO: {api_url}  ({role})')
+    print('=' * 60)
     try:
         response = requests.post(
             f'{api_url}/api/upload/observations',
             headers=headers,
-            files=files,
-            timeout=30
+            files={'file': (os.path.basename(test_file), payload_bytes)},
+            timeout=30,
         )
         print(f'Status: {response.status_code}')
         print(f'Response: {response.text}')
-        sys.exit(0 if response.status_code == 200 else 1)
+        ok = response.status_code == 200
     except Exception as e:
         print(f'Error: {e}')
-        sys.exit(1)
+        ok = False
+
+    if idx == 0:
+        primary_ok = ok
+    elif not ok:
+        mirror_failures.append(api_url)
+
+if mirror_failures:
+    print(f'Mirror failures: {", ".join(mirror_failures)}')
+sys.exit(0 if primary_ok else 1)
 EOF
     then
-        echo -e "${GREEN}✓ Test upload successful!${NC}"
+        echo -e "${GREEN}✓ Primary upload succeeded (mirror failures, if any, did not fail the job)${NC}"
     else
-        echo -e "${RED}✗ Test upload failed${NC}"
+        echo -e "${RED}✗ Primary upload failed${NC}"
         echo ""
         echo "Common issues:"
         echo "  1. API key mismatch - check DATA_UPLOAD_API_KEY"
         echo "  2. Origin validation - must run from chpc.utah.edu"
-        echo "  3. Network/firewall blocking HTTPS to basinwx.com"
+        echo "  3. Network/firewall blocking HTTPS to the primary destination"
         exit 1
     fi
 else
@@ -249,5 +280,6 @@ echo ""
 echo "You're ready to:"
 echo "  1. Set up cron jobs for automated uploads"
 echo "  2. Monitor /tmp/basinwx_upload.log"
-echo "  3. Check data freshness at $BASINWX_API_URL/api/monitoring/freshness"
+echo "  3. Check data freshness at $PRIMARY_URL/api/monitoring/freshness"
+echo "     (mirrors: $BASINWX_API_URLS)"
 echo ""

--- a/docs/CHPC-DEPLOYMENT.md
+++ b/docs/CHPC-DEPLOYMENT.md
@@ -45,7 +45,7 @@ Create a `.env` file or add to your shell profile:
 ```bash
 # ~/.bashrc or ~/.bash_profile
 export BASINWX_API_KEY="your-api-key-here"
-export BASINWX_API_URL="https://basinwx.com"
+export BASINWX_API_URLS="https://basinwx.com"
 export CHPC_HOSTNAME="$(hostname -f)"
 ```
 
@@ -290,7 +290,7 @@ crontab -e
 # Load environment variables
 BASINWX_API_KEY=your-api-key-here
 SYNOPTIC_API_TOKEN=your-synoptic-token-here
-BASINWX_API_URL=https://basinwx.com
+BASINWX_API_URLS=https://basinwx.com
 
 # Observations: Every 10 minutes
 */10 * * * * cd ~/basinwx-pipeline && ./fetch_and_upload.py >> /tmp/basinwx_cron.log 2>&1

--- a/docs/DATA-PIPELINE-OVERVIEW.md
+++ b/docs/DATA-PIPELINE-OVERVIEW.md
@@ -213,7 +213,7 @@ python chpc_uploader.py --health-check
 2. **Set environment variables:**
    ```bash
    export DATA_UPLOAD_API_KEY="your-key-here"
-   export BASINWX_API_URL="https://basinwx.com"
+   export BASINWX_API_URLS="https://basinwx.com"
    ```
 
 3. **Test connection:**
@@ -387,7 +387,7 @@ npm run test-api
 python chpc_uploader.py --validate-only --file test.json --data-type observations
 
 # Test upload to staging
-BASINWX_API_URL="https://staging.basinwx.com" python chpc_uploader.py --data-type observations --file test.json
+BASINWX_API_URLS="https://staging.basinwx.com" python chpc_uploader.py --data-type observations --file test.json
 
 # Health check
 python chpc_uploader.py --health-check
@@ -413,7 +413,7 @@ python chpc_uploader.py --health-check
 ### CHPC
 ```bash
 DATA_UPLOAD_API_KEY     # API key for authentication
-BASINWX_API_URL         # Base URL (default: https://basinwx.com)
+BASINWX_API_URLS         # Base URL (default: https://basinwx.com)
 SYNOPTIC_API_TOKEN      # Synoptic Weather API token
 ```
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -116,7 +116,11 @@ sudo -u deploy bash -lc '
   git fetch --all &&
   git checkout <feature-branch> &&
   npm ci &&
-  pm2 delete all &&                          # app name is branch-derived, clean slate avoids orphans
+  # Delete only our own branch-derived pm2 apps. Never "pm2 delete all" — it
+  # nukes unrelated apps running under the same deploy user.
+  for app in $(pm2 jlist | python3 -c "import json,sys; print(\"\\n\".join(a[\"name\"] for a in json.load(sys.stdin) if a[\"name\"].startswith(\"basinwx-\")))"); do
+    pm2 delete "$app"
+  done &&
   pm2 start ecosystem.config.cjs &&
   pm2 save
 '

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,200 @@
+# Deployment runbook — ubair-website
+
+Canonical runbook for bringing up, operating, and troubleshooting `ubair-website` on the two Linode boxes. Same procedure works on both; the only difference is which branch and which domain.
+
+## 1. Topology
+
+| Role | Branch | Domain | pm2 app name | Typical port | Repo path |
+|---|---|---|---|---|---|
+| Production | `ops` | `www.basinwx.com` | `basinwx-ops` | `3000` | `/srv/ubair-website` |
+| Rehearsal mirror | `dev` | `www.basinwx.dev` | `basinwx-dev` | `3001` | `/srv/ubair-website` |
+
+- Runtime: Node.js under pm2, started as the `deploy` user.
+- TLS: nginx reverse proxy, Let's Encrypt certs under `/etc/letsencrypt/live/<domain>/`.
+- pm2 app name is **derived from the checked-out branch** (`git rev-parse --abbrev-ref HEAD`). See `ecosystem.config.cjs`.
+- `www.basinwx.dev` is a **rehearsal mirror** of production: it receives the same CHPC data via fan-out upload, but runs whichever branch is checked out. Merging a PR into `dev` is the dry-run before promoting to `ops`.
+
+## 2. Deploy vs sudo — user boundary
+
+| Acts as `deploy` (no sudo) | Needs `sudo` |
+|---|---|
+| `git pull`, `git checkout` | `nginx -t`, `systemctl reload nginx` |
+| `npm ci`, `npm run` | `certbot ...` |
+| `pm2 start/reload/save/logs` | `systemctl` (incl. `pm2-deploy` unit setup) |
+| read/write `/srv/ubair-website` | write `/etc/nginx/`, `/etc/letsencrypt/` |
+| read `.env` | `chmod`/`chown` under `/etc` |
+
+Keep both boxes consistent with this split. `deploy` must own `/srv/ubair-website` recursively.
+
+## 3. Fresh-box bring-up
+
+One-time per server. Substitute `<domain>` = `basinwx.dev` or `basinwx.com`, `<port>` = matching value.
+
+```bash
+# 3.1 Clone and permissions
+sudo mkdir -p /srv/ubair-website
+sudo chown -R deploy:deploy /srv/ubair-website
+sudo -u deploy git clone https://github.com/Bingham-Research-Center/ubair-website.git /srv/ubair-website
+cd /srv/ubair-website
+sudo -u deploy git checkout <dev|ops>
+
+# 3.2 Install
+sudo -u deploy npm ci
+
+# 3.3 Environment
+sudo -u deploy cp .env.example .env
+sudo -u deploy $EDITOR .env           # fill in DATA_UPLOAD_API_KEY, UDOT_API_KEY, SYNOPTIC_API_TOKEN, etc.
+sudo chmod 600 /srv/ubair-website/.env
+sudo chown deploy:deploy /srv/ubair-website/.env
+
+# 3.4 Obtain TLS cert (nginx plugin will also write a baseline vhost; we'll overwrite it next)
+sudo certbot certonly --nginx -d <domain> -d www.<domain>
+sudo ls -l /etc/letsencrypt/live/<domain>/    # verify fullchain.pem + privkey.pem exist
+
+# 3.5 Install the nginx vhost (template below)
+sudo $EDITOR /etc/nginx/sites-available/<domain>
+sudo ln -sf /etc/nginx/sites-available/<domain> /etc/nginx/sites-enabled/<domain>
+sudo nginx -t
+sudo systemctl reload nginx
+
+# 3.6 Start the app under pm2
+sudo -u deploy bash -lc 'cd /srv/ubair-website && pm2 start ecosystem.config.cjs'
+
+# 3.7 Persist pm2 across reboots (run the exact command pm2 emits, not the template below)
+sudo env PATH=$PATH:/usr/bin pm2 startup systemd -u deploy --hp /home/deploy
+sudo -u deploy bash -lc 'pm2 save'
+
+# 3.8 Validate
+curl -I http://127.0.0.1:<port>/            # expect 200
+curl -I https://www.<domain>/                # expect 200 (HTTP/2)
+```
+
+## 4. nginx vhost template
+
+Save as `/etc/nginx/sites-available/<domain>`, substitute `<domain>` and `<port>`:
+
+```nginx
+server {
+    listen 80;
+    listen [::]:80;
+    server_name <domain> www.<domain>;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name <domain> www.<domain>;
+
+    ssl_certificate /etc/letsencrypt/live/<domain>/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/<domain>/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:<port>;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+```
+
+If certbot stored the cert under a different directory name, check `sudo ls -l /etc/letsencrypt/live/` and update the `ssl_certificate*` paths accordingly.
+
+## 5. Routine operations
+
+### Pull a new commit into the running branch
+
+```bash
+sudo -u deploy bash -lc 'cd /srv/ubair-website && git pull && npm ci && pm2 reload ecosystem.config.cjs --update-env && pm2 save'
+```
+
+### Swap the dev box to a feature branch for a demo
+
+```bash
+sudo -u deploy bash -lc '
+  cd /srv/ubair-website &&
+  git fetch --all &&
+  git checkout <feature-branch> &&
+  npm ci &&
+  pm2 delete all &&                          # app name is branch-derived, clean slate avoids orphans
+  pm2 start ecosystem.config.cjs &&
+  pm2 save
+'
+```
+
+Swap back to `dev` with the same sequence. The pm2 app name auto-becomes `basinwx-<branch>`.
+
+### Certificate renewal
+
+certbot installs a systemd timer that renews automatically. Verify:
+
+```bash
+systemctl list-timers | grep certbot
+sudo certbot renew --dry-run
+```
+
+If nginx isn't reloading after renewal, check `/etc/letsencrypt/renewal-hooks/deploy/` for a reload hook, or add one:
+
+```bash
+echo -e '#!/bin/sh\nsystemctl reload nginx' | sudo tee /etc/letsencrypt/renewal-hooks/deploy/nginx-reload
+sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/nginx-reload
+```
+
+## 6. "Did this work?" — ordered sanity checklist
+
+Run these top-to-bottom when the browser shows an unexpected response. First failing step is the diagnosis.
+
+```bash
+# 6.1  Right branch?
+cd /srv/ubair-website && git branch --show-current
+
+# 6.2  pm2 process online and named correctly?
+pm2 list                                       # expect: basinwx-<branch>, status online
+
+# 6.3  pm2 survives reboot?
+systemctl list-unit-files | grep pm2           # expect: pm2-deploy.service  enabled
+# If empty: sudo env PATH=$PATH:/usr/bin pm2 startup systemd -u deploy --hp /home/deploy
+
+# 6.4  .env locked down?
+ls -l /srv/ubair-website/.env                  # expect: -rw-------  deploy deploy
+
+# 6.5  App responding internally?
+PORT=$(grep -E '^PORT=' /srv/ubair-website/.env | cut -d= -f2)
+curl -I http://127.0.0.1:${PORT}/              # expect: HTTP/1.1 200
+
+# 6.6  nginx config valid?
+sudo nginx -t
+
+# 6.7  nginx listening on both 80 and 443?
+ss -tlnp | grep -E ':(80|443)\b'
+
+# 6.8  Cert present and not near expiry?
+sudo certbot certificates                      # expect: > 30 days to expiry
+
+# 6.9  External HTTPS OK?
+curl -I https://www.<domain>/                  # expect: HTTP/2 200
+
+# 6.10 Recent pm2 log history clean?
+pm2 logs basinwx-$(git -C /srv/ubair-website branch --show-current) --lines 50 --nostream
+```
+
+## 7. CHPC data fan-out
+
+CHPC runs `scripts/chpc_uploader.py` and the shell helpers in `chpc-deployment/`. The uploader consumes **`BASINWX_API_URLS`** (comma-separated). First URL is **primary** — its failure fails the job. Remaining URLs are **best-effort mirrors** — failures emit a loud WARN but the job still exits 0.
+
+Recommended CHPC env:
+
+```bash
+export BASINWX_API_KEY="..."                            # matches DATA_UPLOAD_API_KEY on the servers
+export BASINWX_API_URLS="https://basinwx.com,https://basinwx.dev"
+```
+
+To temporarily stop mirroring to dev (e.g., during dev-side maintenance), drop `basinwx.dev` from the list. To upload **only** to dev (e.g., testing a pipeline change), set `BASINWX_API_URLS="https://basinwx.dev"` alone.
+
+## 8. Known gotchas
+
+- **`.dev` TLDs are HSTS-preloaded.** Browsers refuse plain HTTP. The nginx template above returns 301 → HTTPS which is required, not a nice-to-have.
+- **`deploy` vs. `sudo` user.** pm2's state (`~/.pm2/`) lives in `deploy`'s home. Never run pm2 as root or any other user, or you end up with two separate daemons and mystifying "process not found" behaviour.
+- **pm2 startup unit.** Without it, a reboot silently loses the site. Step 3.7 is not optional.
+- **Heap default.** Node defaults to ~1.5 GB old-space but Linode boxes can OOM under concurrent loads. `ecosystem.config.cjs` sets `max_memory_restart: 512M` as a guardrail; if you see repeated restarts, investigate logs before raising the ceiling.
+- **Secrets in scripts.** The CHPC setup script must read `DATA_UPLOAD_API_KEY` from env, not carry it as a literal. If you rotate the key, rotate it in the server `.env` files and on CHPC at the same time.

--- a/docs/MANIFEST-GUIDE.md
+++ b/docs/MANIFEST-GUIDE.md
@@ -253,7 +253,7 @@ python chpc_uploader.py --validate-only --file test_data.json --data-type observ
 
 ```bash
 # Test with real endpoint (use staging if available)
-BASINWX_API_URL="https://staging.basinwx.com" \
+BASINWX_API_URLS="https://staging.basinwx.com" \
 python chpc_uploader.py --file test_data.json --data-type observations
 ```
 

--- a/docs/PYTHON-PACKAGING-DEPLOYMENT.md
+++ b/docs/PYTHON-PACKAGING-DEPLOYMENT.md
@@ -177,7 +177,7 @@ DATA_UPLOAD_API_KEY=abc123xyz789
 SYNOPTIC_API_TOKEN=my-token-here
 
 # Configuration (non-secrets)
-BASINWX_API_URL=https://basinwx.com
+BASINWX_API_URLS=https://basinwx.com
 LOG_LEVEL=INFO
 ```
 
@@ -201,14 +201,14 @@ DATA_UPLOAD_API_KEY=your-key-here
 SYNOPTIC_API_TOKEN=your-token-here
 
 # Optional: Custom website URL
-BASINWX_API_URL=https://basinwx.com
+BASINWX_API_URLS=https://basinwx.com
 ```
 
 **`.env` (NOT in git, each user creates their own):**
 ```bash
 DATA_UPLOAD_API_KEY=sk_live_abc123xyz789
 SYNOPTIC_API_TOKEN=f7a3b9c1d2e4
-BASINWX_API_URL=https://staging.basinwx.com  # Testing on staging
+BASINWX_API_URLS=https://staging.basinwx.com  # Testing on staging
 ```
 
 ### Using .env in Python
@@ -448,7 +448,7 @@ cat > ~/.bashrc_basinwx <<'EOF'
 # BasinWx Secrets
 export DATA_UPLOAD_API_KEY="your-production-key-here"
 export SYNOPTIC_API_TOKEN="your-synoptic-token"
-export BASINWX_API_URL="https://basinwx.com"
+export BASINWX_API_URLS="https://basinwx.com"
 EOF
 
 chmod 600 ~/.bashrc_basinwx  # Protect secrets

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -50,7 +50,7 @@ chmod +x chpc_uploader.py
 cat >> ~/.bashrc << 'EOF'
 # BasinWx Data Pipeline
 export BASINWX_API_KEY="your-api-key-here"
-export BASINWX_API_URL="https://basinwx.com"
+export BASINWX_API_URLS="https://basinwx.com"
 EOF
 
 # Reload
@@ -179,7 +179,7 @@ Add these lines:
 ```cron
 # Environment
 BASINWX_API_KEY=your-api-key-here
-BASINWX_API_URL=https://basinwx.com
+BASINWX_API_URLS=https://basinwx.com
 
 # Send observations every 10 minutes
 */10 * * * * cd ~/basinwx-pipeline && ./send_observations.py >> /tmp/basinwx.log 2>&1

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,30 @@
+const { execSync } = require('child_process');
+
+function currentBranch() {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: __dirname,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim() || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+const branch = currentBranch();
+
+module.exports = {
+  apps: [
+    {
+      name: `basinwx-${branch}`,
+      script: 'server/server.js',
+      cwd: __dirname,
+      env: {
+        NODE_ENV: branch === 'ops' ? 'production' : 'development',
+      },
+      max_memory_restart: '512M',
+      exp_backoff_restart_delay: 5000,
+      time: true,
+    },
+  ],
+};

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -11,7 +11,11 @@ function currentBranch() {
   }
 }
 
-const branch = currentBranch();
+const rawBranch = currentBranch();
+const branch = rawBranch
+  .replace(/[^A-Za-z0-9_-]/g, '-')
+  .replace(/-+/g, '-')
+  .replace(/^-+|-+$/g, '') || 'unknown';
 
 module.exports = {
   apps: [

--- a/public/js/loadSidebar.js
+++ b/public/js/loadSidebar.js
@@ -52,6 +52,12 @@ async function loadSidebar() {
         const content = await response.text();
         sidebarContainer.innerHTML = content;
 
+        const host = window.location.host.replace(/^www\./, '') || 'basinwx.com';
+        const brandEl = sidebarContainer.querySelector('.sidebar-logo-title');
+        if (brandEl) brandEl.textContent = host;
+        const brandLink = sidebarContainer.querySelector('.sidebar-logo a');
+        if (brandLink) brandLink.title = `${host} - Home`;
+
         const currentPath = window.location.pathname;
         const currentPageLink = document.querySelector(`.sidebar a[href="${currentPath}"]`);
         if (currentPageLink) {

--- a/scripts/chpc_uploader.py
+++ b/scripts/chpc_uploader.py
@@ -10,8 +10,12 @@ Usage:
     python chpc_uploader.py --validate-only --file data.json
 
 Environment Variables:
-    BASINWX_API_KEY    : API key for authentication
-    BASINWX_API_URL    : Base URL (default: https://basinwx.com)
+    BASINWX_API_KEY    : API key for authentication (required)
+    BASINWX_API_URLS   : Comma-separated destination URLs (required, no default).
+                         The first URL is the primary destination — a failure on it fails the job.
+                         Remaining URLs are best-effort mirrors — their failures are logged as
+                         WARN but do not fail the job. Typical CHPC value:
+                             BASINWX_API_URLS="https://basinwx.com,https://basinwx.dev"
     CHPC_HOSTNAME      : Hostname to send in headers
 """
 
@@ -185,10 +189,50 @@ class DataValidator:
         return True
 
 
-class BasinWxUploader:
-    """Handles uploading data to BasinWx API"""
+def parse_api_urls() -> List[str]:
+    """Parse BASINWX_API_URLS into a de-duped, non-empty list of base URLs.
 
-    def __init__(self, api_key: str, api_url: str = "https://basinwx.com"):
+    First entry is treated as the primary destination; remaining entries are
+    best-effort mirrors. Raises SystemExit(2) if unset or empty so misconfigured
+    runs fail loudly instead of silently hitting a default destination.
+    """
+    raw = os.environ.get('BASINWX_API_URLS', '').strip()
+    if not raw:
+        logger.error(
+            "BASINWX_API_URLS is not set. Provide a comma-separated list, e.g. "
+            "BASINWX_API_URLS=\"https://basinwx.com,https://basinwx.dev\". "
+            "There is no default — this prevents accidentally uploading to prod."
+        )
+        sys.exit(2)
+    urls: List[str] = []
+    seen = set()
+    for part in raw.split(','):
+        url = part.strip().rstrip('/')
+        if url and url not in seen:
+            urls.append(url)
+            seen.add(url)
+    if not urls:
+        logger.error("BASINWX_API_URLS parsed to an empty list: %r", raw)
+        sys.exit(2)
+    return urls
+
+
+def _destination_role(index: int) -> str:
+    return 'primary' if index == 0 else 'mirror'
+
+
+def _log_banner(index: int, api_url: str) -> None:
+    role = _destination_role(index)
+    bar = '=' * 60
+    logger.info(bar)
+    logger.info("UPLOADING TO: %s  (%s)", api_url, role.upper())
+    logger.info(bar)
+
+
+class BasinWxUploader:
+    """Handles uploading data to one BasinWx destination."""
+
+    def __init__(self, api_key: str, api_url: str):
         self.api_key = api_key
         self.api_url = api_url.rstrip('/')
         self.session = requests.Session()
@@ -308,15 +352,21 @@ def main():
     # Health check only
     if args.health_check:
         api_key = os.environ.get('BASINWX_API_KEY')
-        api_url = os.environ.get('BASINWX_API_URL', 'https://basinwx.com')
-
         if not api_key:
             logger.error("BASINWX_API_KEY environment variable not set")
             sys.exit(1)
 
-        uploader = BasinWxUploader(api_key, api_url)
-        success = uploader.health_check()
-        sys.exit(0 if success else 1)
+        api_urls = parse_api_urls()
+        primary_ok = True
+        for idx, api_url in enumerate(api_urls):
+            _log_banner(idx, api_url)
+            uploader = BasinWxUploader(api_key, api_url)
+            ok = uploader.health_check()
+            if idx == 0:
+                primary_ok = ok
+            elif not ok:
+                logger.warning("Mirror health check failed for %s (continuing)", api_url)
+        sys.exit(0 if primary_ok else 1)
 
     # Validate arguments
     if not args.file or not args.data_type:
@@ -358,24 +408,41 @@ def main():
         logger.info("Validation complete (no upload performed)")
         sys.exit(0)
 
-    # Upload
+    # Upload — fan out to every destination in BASINWX_API_URLS
     api_key = os.environ.get('BASINWX_API_KEY')
-    api_url = os.environ.get('BASINWX_API_URL', 'https://basinwx.com')
-
     if not api_key:
         logger.error("BASINWX_API_KEY environment variable not set")
         sys.exit(1)
 
-    uploader = BasinWxUploader(api_key, api_url)
+    api_urls = parse_api_urls()
+    primary_ok = False
+    mirror_failures: List[str] = []
 
-    # Health check first
-    if not uploader.health_check():
-        logger.warning("API health check failed, but proceeding with upload...")
+    for idx, api_url in enumerate(api_urls):
+        _log_banner(idx, api_url)
+        uploader = BasinWxUploader(api_key, api_url)
 
-    # Upload file
-    success = uploader.upload_file(args.file, args.data_type)
+        if not uploader.health_check():
+            logger.warning("Health check failed for %s, proceeding with upload attempt anyway",
+                           api_url)
 
-    sys.exit(0 if success else 1)
+        success = uploader.upload_file(args.file, args.data_type)
+        if idx == 0:
+            primary_ok = success
+            if not success:
+                logger.error("Primary upload failed (%s) — job will exit non-zero", api_url)
+        else:
+            if success:
+                logger.info("Mirror upload succeeded: %s", api_url)
+            else:
+                logger.warning("Mirror upload FAILED: %s (job still succeeds if primary did)",
+                               api_url)
+                mirror_failures.append(api_url)
+
+    if mirror_failures:
+        logger.warning("Mirror failures summary: %s", ', '.join(mirror_failures))
+
+    sys.exit(0 if primary_ok else 1)
 
 
 if __name__ == '__main__':

--- a/ubair-diagnostic.sh
+++ b/ubair-diagnostic.sh
@@ -3,7 +3,7 @@
 # Run on both Akamai and CHPC to compare data state
 #
 # Usage (from ubair-website repo on either server):
-#   cd ~/gits/ubair-website  # or wherever the repo is
+#   cd /srv/ubair-website  # or wherever the repo is
 #   bash ubair-diagnostic.sh > diagnostic-$(hostname)-$(date +%Y%m%d-%H%M).txt 2>&1
 #
 # Conda env on CHPC: integration-clyfar-v0.9.5
@@ -17,10 +17,42 @@ echo "User: $(whoami)"
 echo "PWD: $(pwd)"
 echo ""
 
+CURRENT_USER="$(whoami)"
+CURRENT_PWD="$(pwd -P)"
+
+# Default PUBLIC_DOMAIN from the checked-out branch (dev → basinwx.dev, ops → basinwx.com).
+# Override explicitly if running this script from a feature branch or elsewhere:
+#   PUBLIC_DOMAIN=basinwx.dev bash ubair-diagnostic.sh
+if [[ -z "${PUBLIC_DOMAIN:-}" ]]; then
+    DETECTED_BRANCH="$(git -C "$CURRENT_PWD" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    case "$DETECTED_BRANCH" in
+        ops)  PUBLIC_DOMAIN="basinwx.com" ;;
+        dev)  PUBLIC_DOMAIN="basinwx.dev" ;;
+        *)    PUBLIC_DOMAIN=""
+              echo "NOTE: could not auto-detect public domain from branch '$DETECTED_BRANCH'."
+              echo "      Set it explicitly, e.g.:  PUBLIC_DOMAIN=basinwx.dev $0"
+              ;;
+    esac
+fi
+PUBLIC_BASE_URL="${PUBLIC_BASE_URL:-${PUBLIC_DOMAIN:+https://${PUBLIC_DOMAIN}}}"
+PM2_RUNNER="$CURRENT_USER"
+
+if [[ "$PM2_RUNNER" != "deploy" ]] && id deploy >/dev/null 2>&1; then
+    PM2_RUNNER="deploy"
+fi
+
+run_pm2() {
+    if [[ "$PM2_RUNNER" == "$CURRENT_USER" ]]; then
+        pm2 "$@"
+    else
+        runuser -l "$PM2_RUNNER" -c "$(printf 'pm2 %q ' "$@")"
+    fi
+}
+
 # Detect server type
 if [[ $(hostname) == *"chpc"* ]] || [[ $(hostname) == *"notch"* ]] || [[ -d "$HOME/gits/clyfar" ]]; then
     SERVER_TYPE="CHPC"
-elif [[ -d "/var/www" ]] || [[ -d "$HOME/ubair-website" ]]; then
+elif [[ -d "/srv/ubair-website" ]] || [[ -d "/var/www" ]] || [[ -d "$HOME/ubair-website" ]]; then
     SERVER_TYPE="AKAMAI"
 else
     SERVER_TYPE="UNKNOWN"
@@ -34,14 +66,16 @@ echo "========================================"
 
 # Find the website root
 WEBSITE_ROOTS=(
+    "/srv/ubair-website"
     "$HOME/ubair-website"
     "$HOME/gits/ubair-website"
     "/var/www/ubair-website"
     "/var/www/html/ubair-website"
-    "$(pwd)"
+    "$CURRENT_PWD"
 )
 
 WEBSITE_ROOT=""
+LOCAL_PORT="3000"
 for dir in "${WEBSITE_ROOTS[@]}"; do
     if [[ -d "$dir/public/api/static" ]]; then
         WEBSITE_ROOT="$dir"
@@ -54,6 +88,17 @@ if [[ -n "$WEBSITE_ROOT" ]]; then
     echo ""
 
     STATIC_DIR="$WEBSITE_ROOT/public/api/static"
+
+    if [[ -f "$WEBSITE_ROOT/.env" ]]; then
+        ENV_PORT=$(grep -E '^PORT=' "$WEBSITE_ROOT/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '"'\''[:space:]')
+        if [[ "$ENV_PORT" =~ ^[0-9]+$ ]]; then
+            LOCAL_PORT="$ENV_PORT"
+        fi
+    fi
+
+    echo "Local app port: $LOCAL_PORT"
+    echo "Public base URL: $PUBLIC_BASE_URL"
+    echo ""
 
     echo "--- Directory structure ---"
     ls -la "$STATIC_DIR" 2>/dev/null || echo "Cannot access $STATIC_DIR"
@@ -207,12 +252,15 @@ echo "3. NODE/PM2 STATUS (AKAMAI ONLY)"
 echo "========================================"
 
 if [[ "$SERVER_TYPE" == "AKAMAI" ]] || command -v pm2 &> /dev/null; then
+    echo "PM2 context user: $PM2_RUNNER"
+    echo ""
+
     echo "--- PM2 processes ---"
-    pm2 list 2>/dev/null || echo "PM2 not available or not running"
+    run_pm2 list 2>/dev/null || echo "PM2 not available or not running"
     echo ""
 
     echo "--- PM2 logs (last 30 lines) ---"
-    pm2 logs --lines 30 --nostream 2>/dev/null || echo "Cannot get PM2 logs"
+    run_pm2 logs --lines 30 --nostream 2>/dev/null || echo "Cannot get PM2 logs"
     echo ""
 
     echo "--- Node version ---"
@@ -239,16 +287,20 @@ echo "========================================"
 # Test local API if server is running
 echo "--- Testing localhost API ---"
 for endpoint in "/api/filelist/observations" "/api/filelist/images" "/api/filelist/forecasts"; do
-    echo "GET http://localhost:3000$endpoint"
-    curl -s -o /dev/null -w "HTTP %{http_code}\n" "http://localhost:3000$endpoint" 2>/dev/null || echo "Failed/not running"
+    echo "GET http://127.0.0.1:${LOCAL_PORT}$endpoint"
+    curl -s -o /dev/null -w "HTTP %{http_code}\n" "http://127.0.0.1:${LOCAL_PORT}$endpoint" 2>/dev/null || echo "Failed/not running"
 done
 echo ""
 
 echo "--- Testing production API ---"
-for endpoint in "/api/filelist/observations" "/api/filelist/images" "/api/filelist/forecasts"; do
-    echo "GET https://basinwx.com$endpoint"
-    curl -s -o /dev/null -w "HTTP %{http_code}\n" "https://basinwx.com$endpoint" 2>/dev/null || echo "Failed"
-done
+if [[ -n "$PUBLIC_BASE_URL" ]]; then
+    for endpoint in "/api/filelist/observations" "/api/filelist/images" "/api/filelist/forecasts"; do
+        echo "GET ${PUBLIC_BASE_URL}$endpoint"
+        curl -s -o /dev/null -w "HTTP %{http_code}\n" "${PUBLIC_BASE_URL}$endpoint" 2>/dev/null || echo "Failed"
+    done
+else
+    echo "Skipped (PUBLIC_BASE_URL not set — pass PUBLIC_DOMAIN=... to enable)"
+fi
 echo ""
 
 echo "========================================"


### PR DESCRIPTION
## Summary

Make the operational core of `ubair-website` agnostic to which of the two Linode boxes / branches it runs on, add a real bring-up runbook, and tighten the CHPC uploader to a fan-out pattern so `www.basinwx.dev` can be a true rehearsal mirror of production.

Audit finding that prompted this work: the dev box was serving HTTP/2 200 end-to-end via nginx → pm2 → Node on `:3001`, but there was **no systemd unit for pm2** (a reboot would lose the site), no `ecosystem.config.*`, `.env` was mode `664`, CLAUDE.md and scripts hardcoded `basinwx.com`, and `chpc-deployment/setup_chpc_env.sh` contained a **literal DATA_UPLOAD_API_KEY** in git.

### Changes
- **`ecosystem.config.cjs`** (new) — pm2 app name = `basinwx-${git-branch}`, `max_memory_restart: 512M`, exp-backoff. Same file DTRT on both boxes.
- **`docs/DEPLOYMENT.md`** (new) — topology table, fresh-box bring-up checklist, nginx vhost template, branch-swap procedure for dev-box demos, certbot renewal, and an ordered "did this work?" sanity checklist for browser-refresh debugging. Folds in the useful content from the now-deleted `handoff-issues-21apr.md`.
- **`CLAUDE.md`** — Deployment Topology section; no more hardcoded domains/ports.
- **`.env.example`** — covers every `process.env.X` the app reads (NODE_ENV, APP_URL, BASE_URL, SYNOPTIC_API_KEY, all REPORT_EMAIL_*); marks per-server vs shared vars; notes `chmod 600`.
- **`public/js/loadSidebar.js`** — sidebar brand reflects `window.location.host`, so the dev box self-identifies as `basinwx.dev` to demo stakeholders.
- **`ubair-diagnostic.sh`** — `PUBLIC_DOMAIN` auto-detects from branch (`dev` → `basinwx.dev`, `ops` → `basinwx.com`) instead of defaulting to `basinwx.dev` everywhere.
- **CHPC uploader fan-out** (`scripts/chpc_uploader.py`, `chpc-deployment/test_upload.sh`, `chpc-deployment/setup_chpc_env.sh`):
  - `BASINWX_API_URL` → `BASINWX_API_URLS` (comma-separated).
  - No silent default. Unset → loud exit 2.
  - First URL = primary (failure fails the job). Rest = best-effort mirrors (failures log WARN but do not fail the job).
  - Each destination logs `UPLOADING TO: <url> (PRIMARY|MIRROR)`.
  - Removed literal API key from `setup_chpc_env.sh`; script now reads env or prompts.

### Sysadmin follow-up (documented in `docs/DEPLOYMENT.md` — not in this PR)
- `sudo env PATH=$PATH:/usr/bin pm2 startup systemd -u deploy --hp /home/deploy && pm2 save` — persist pm2 across reboot
- `chmod 600 /srv/ubair-website/.env`
- Rotate the DATA_UPLOAD_API_KEY that was previously hardcoded in the CHPC setup script
- Apply the same runbook on the ops box (www.basinwx.com)

## Test plan
- [ ] `node -e "require('./ecosystem.config.cjs')"` loads, app name derives from branch
- [ ] `bash -n` passes on the three shell scripts; `python3 -c "import ast; ast.parse(open('scripts/chpc_uploader.py').read())"` passes
- [ ] `https://www.basinwx.dev/` still returns HTTP/2 200 (verified pre-push)
- [ ] Every `process.env.X` referenced in `server/`, `scripts/`, `public/` appears in `.env.example` (verified via comm diff)
- [ ] After merge + `pm2 delete basinwx-dev && pm2 start ecosystem.config.cjs && pm2 save`: pm2 app name is `basinwx-dev`, site still 200
- [ ] After `pm2 startup` + `pm2 save`: `sudo reboot` brings the site back within 60s
- [ ] CHPC dry-run: `BASINWX_API_URLS="https://basinwx.dev"` alone uploads to dev; full list uploads to both; intentional bad mirror URL leaves primary exit-0 with WARN log
- [ ] Sidebar brand reads `basinwx.dev` on the dev box, `basinwx.com` on the ops box

🤖 Generated with [Claude Code](https://claude.com/claude-code)