### PR TITLE
fix: remove legacy /api/filelist.json fossil route

### DIFF
--- a/docs/DATA-SCHEMA.md
+++ b/docs/DATA-SCHEMA.md
@@ -60,7 +60,11 @@ Data flows from CHPC (brc-tools Python repo) → Akamai (ubair-website Node.js r
 ## API Endpoints
 - **Upload:** `POST /api/upload/:dataType` (CHPC only)
 - **Fetch data:** `GET /api/static/{filename}`
-- **File list:** `GET /api/filelist.json`
+- **File list:** `GET /api/filelist/:dataType` (dynamic listing of the per-data-type directory)
+
+> The older `/api/filelist.json` route was removed in 2026-04 because it
+> served a static fossil that never updated and misled operators during
+> diagnostics. Use `/api/filelist/:dataType` instead.
 
 ## Testing Workflow
 

--- a/server/server.js
+++ b/server/server.js
@@ -125,14 +125,11 @@ app.get('/about/:page', (req, res) => {
     res.sendFile(path.join(__dirname, `../views/about/${req.params.page}.html`));
 });
 
-app.get('/api/filelist.json', async (req, res) => {
-    try {
-        const data = await fs.readFile('./public/api/static/filelist.json');
-        res.json(JSON.parse(data));
-    } catch (error) {
-        res.status(500).json({ error: 'Failed to fetch file list' });
-    }
-});
+// NOTE: The legacy /api/filelist.json route was removed in 2026-04 — it
+// served a deploy-time fossil (./public/api/static/filelist.json) that
+// nothing ever regenerated, so it pinned operators to stale snapshots
+// during diagnostics. Use /api/filelist/:dataType below (dynamic
+// fs.readdir on the per-type directory) instead.
 
 app.get('/api/filelist/:dataType', async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- Removes the `/api/filelist.json` handler in `server/server.js`. It was reading a deploy-time snapshot (`./public/api/static/filelist.json`) that no code ever regenerates.
- Updates `docs/DATA-SCHEMA.md` to document `/api/filelist/:dataType` as the sole file-list endpoint.

## Motivation
On 2026-04-23, diagnostics on CHPC were badly derailed by this route. Both basinwx.com and basinwx.dev returned the same two-file snapshot from 2025-07-31 02:28Z, suggesting CHPC had been silent for 9 months. In reality:

- `~/logs/obs.log` on CHPC showed 432 successful uploads today (every 5 min).
- `/api/filelist/observations` returned 39 082 files with today's latest obs at 18:00Z.
- Today's obs files were directly fetchable at `/api/static/observations/map_obs_20260423_*Z.json`.

The static `filelist.json` is a fossil. It misleads operators curling the site for a sanity check.

## Blast radius
- **Frontend:** nothing — `public/js/api.js`, `forecast_air_quality.js`, and `forecast_weather.js` all call `/api/filelist/:dataType` (which is dynamic, `fs.readdir`-based, and works correctly).
- **Operator docs / examples:** 14 references across `chpc-deployment/*.md` and `docs/CHPC-IMPLEMENTATION.md`, `docs/CRONJOB-ADVICE.md`, `docs/TESTING-PLAN.md`, `docs/archive/*`. Left untouched in this PR to keep the diff minimal — anyone hitting the removed route now gets a 404 and learns. Worth a follow-up sweep when someone is in those docs anyway.
- **CLAUDE.md line 45** still lists the old route; editing it requires a separate permission grant that didn't come through this session. Trivial follow-up.

## Test plan
- [x] Removed route is not referenced in frontend JS (`rg 'filelist.json' public/js/` — no matches).
- [ ] Merge to `dev`, `pm2 restart` dev on Linode, `curl -I https://basinwx.dev/api/filelist.json` returns 404.
- [ ] `curl https://basinwx.dev/api/filelist/observations` still returns a JSON array (unchanged behaviour).
- [ ] Frontend maps on `basinwx.dev/live_aq` still load (proves no client code depended on the removed route).
- [ ] Cherry-pick to `ops` once verified on `dev`.

## Follow-ups (not in this PR)
- Sweep `chpc-deployment/*.md`, `docs/CHPC-IMPLEMENTATION.md`, `docs/CRONJOB-ADVICE.md`, `docs/TESTING-PLAN.md`, and `CLAUDE.md` line 45 to replace `/api/filelist.json` examples with `/api/filelist/observations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)