### PR TITLE
feat: per-user branch preview apps on subdomains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@
 # ── Server Configuration ─────────────────────────────────────────────
 NODE_ENV=development                            # [per-server] production on ops, development on dev
 PORT=3000                                       # [per-server] 3000 on ops, 3001 on dev (free up 3000 for hot-swap testing)
+# PREVIEW_MODE=true                             # [preview only] set by manage-previews.sh; disables background jobs + report emails
 
 # ── Data Upload API (CHPC → website) ─────────────────────────────────
 # Generate a fresh key per server with: node scripts/generate-api-key.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ The operational core must be agnostic to which server / branch it runs on.
 - **Real-time data**: Automatic refresh every 10 minutes
 
 ## Recent Updates
+- **PR #182 (2026-04-24)**: per-user branch preview apps on subdomains — `preview-apps.json`, `scripts/manage-previews.sh`, `PREVIEW_MODE` gate in `server.js`, `docs/DEPLOYMENT.md` §9; also fixed `routes/trafficEvents.js` to use shared `TrafficEventsService` instance via injection (eliminating separate rate-limiter and cold-start double-poll against UDoT)
 - **PR #178 (2026-04-22)**: operational-agnosticism pass — branch-derived pm2 app name, fan-out CHPC uploader (`BASINWX_API_URLS`), `docs/DEPLOYMENT.md` runbook, host-aware sidebar brand
 - Implemented 90s mode toggle with holographic background
 - Created data schema documentation (DATA_SCHEMA.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ The operational core must be agnostic to which server / branch it runs on.
 - `www.basinwx.dev` receives the same CHPC data as `.com` (fan-out upload) and runs whichever branch is checked out, so merging a PR into `dev` is a real-world dry-run before promotion to `ops`. It is also where stakeholder demos happen.
 - A third developer laptop/VM may also run this repo. It is **not operational**, may have broken paths, and must never be the source of truth.
 - Full bring-up runbook, nginx template, cert renewal, and "did this work?" sanity checklist live in `docs/DEPLOYMENT.md`.
+- **DNS is at Namecheap, not Linode.** Nameservers: `dns1/dns2.registrar-servers.com`. A wildcard A record (`*` → dev-box IP) covers every `<name>.basinwx.dev` subdomain, so new feature-branch previews need no DNS work — only nginx vhost + cert.
+- **Feature-branch previews** live at `<name>.basinwx.dev`, managed by `scripts/manage-previews.sh` + `preview-apps.json`. Runbook: `docs/DEPLOYMENT.md` §9. Background jobs (refresh, report emails) are gated on `PREVIEW_MODE=true` so previews don't double-burn upstream quotas.
 
 ### Bring-up lessons learnt (keep for future re-provisioning)
 - **Linode Cloud Firewall defaults to Drop.** A fresh linode blocks 80/443 until you explicitly accept them. Symptoms: `certbot renew --dry-run` times out on the ACME challenge, site is unreachable externally, but internal `curl -I http://127.0.0.1:${PORT}` works fine. Check each box's firewall rules in the Linode console before assuming nginx or certbot are broken.
@@ -38,6 +40,7 @@ The operational core must be agnostic to which server / branch it runs on.
 - **Time series**: Ozone concentration data
 - **Markdown outlooks**: Weather forecast text
 - **Images**: PNG files for visualization
+- **Forecasts**: Clyfar ensembles (`forecast_possibility_heatmap_*`, `forecast_exceedance_probabilities_*`, `forecast_percentile_scenarios_*`) and reduced HRRR surface layers (`forecast_hrrr_surface_layers_*`). Endpoint: `/api/upload/forecasts`. Full JSON schemas in `DATA_MANIFEST.json` §forecasts (~L247–L629). Server accepts any valid JSON; schema is not enforced server-side, so brc-tools is the contract-holder.
 
 ## API Endpoints
 - **Upload**: `POST /api/upload/:dataType` (CHPC only, API key required)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ CHPC (Data Processing) → API Upload (fan-out) → Linode (.com ops + .dev rehe
 
 - **Backend**: Node.js, Express.js, pm2
 - **Frontend**: Vanilla JavaScript, Leaflet, Plotly.js
-- **Data Pipeline**: Python (brc-tools), Synoptic Weather API
-- **Deployment**: Two Linode boxes (`www.basinwx.com` ops, `www.basinwx.dev` rehearsal mirror), nginx reverse proxy, Let's Encrypt TLS
+- **Data Pipeline**: Python (brc-tools), Synoptic Weather API; forecast products (Clyfar ensembles, reduced HRRR surface layers) POST to `/api/upload/forecasts` — schema in `DATA_MANIFEST.json`
+- **Deployment**: Two Linode boxes (`www.basinwx.com` ops, `www.basinwx.dev` rehearsal mirror), nginx reverse proxy, Let's Encrypt TLS. DNS for `basinwx.dev` is at **Namecheap** with a wildcard A record (`*` → dev-box IP)
+- **Feature-branch previews**: any in-progress branch can be spun up at `<name>.basinwx.dev` via a git worktree + pm2 pair managed by `scripts/manage-previews.sh`. New previews need no DNS work thanks to the wildcard. See `docs/DEPLOYMENT.md` §9
 
 ## Documentation --- still in flux and requiring review for AI slop
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -251,5 +251,6 @@ Add an entry to `preview-apps.json` (choose a port not used by any other process
 ### Notes
 
 - Preview apps do **not** receive CHPC uploads — they read static data from the dev server's shared directory. Do not add a preview URL to `BASINWX_API_URLS`.
-- The feature branch must include the `PREVIEW_MODE` gate (merged from `dev`) for background jobs to be suppressed. Run `scripts/manage-previews.sh update <user>` after the branch syncs with dev.
+- **PREVIEW_MODE must be in the branch code, not just the `.env`.** The gate is a guard inside `server/server.js` that checks `process.env.PREVIEW_MODE`. Setting `PREVIEW_MODE=true` in a preview's `.env` only works if the feature branch already contains the gate (merged from `dev`). Until the branch syncs, the preview will still run `backgroundRefresh` + `reportEmailService` and double-poll UDoT / duplicate report emails.
+  - **Workaround when the branch is not yet synced with dev:** before running `up`, or immediately after, edit `/srv/ubair-website-preview-<user>/.env` and blank the relevant keys — e.g. `UDOT_API_KEY=` and `REPORT_EMAIL_ENABLED=false` — then `scripts/manage-previews.sh update <user>` (or `pm2 restart <pm2_name>`) to pick them up. Restore them after the branch has synced and `PREVIEW_MODE` is doing its job.
 - Ports are hardcoded in `preview-apps.json`; update the file and the nginx vhost if you need to change a port.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -202,3 +202,54 @@ To temporarily stop mirroring to dev (e.g., during dev-side maintenance), drop `
 - **pm2 startup unit.** Without it, a reboot silently loses the site. Step 3.7 is not optional.
 - **Heap default.** Node defaults to ~1.5 GB old-space but Linode boxes can OOM under concurrent loads. `ecosystem.config.cjs` sets `max_memory_restart: 512M` as a guardrail; if you see repeated restarts, investigate logs before raising the ceiling.
 - **Secrets in scripts.** The CHPC setup script must read `DATA_UPLOAD_API_KEY` from env, not carry it as a literal. If you rotate the key, rotate it in the server `.env` files and on CHPC at the same time.
+
+## 9. Per-user branch previews
+
+Preview apps let a developer's feature branch run live on its own subdomain (`<subdomain>.basinwx.dev`) without disturbing the main `dev` deployment. Configuration is in `preview-apps.json` at the repo root.
+
+### Managing previews (as `deploy` user on the dev box)
+
+```bash
+# Start Quinten's sports preview on port 3002 at sports.basinwx.dev
+scripts/manage-previews.sh up quinten
+
+# Get the nginx vhost config
+scripts/manage-previews.sh nginx quinten | sudo tee /etc/nginx/sites-available/sports.basinwx.dev
+sudo ln -s /etc/nginx/sites-available/sports.basinwx.dev /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+
+# Obtain TLS cert (must succeed before HTTPS will work)
+sudo certbot certonly --nginx -d sports.basinwx.dev
+sudo systemctl reload nginx
+
+# Pull latest commits from the feature branch
+scripts/manage-previews.sh update quinten
+
+# Tear down when no longer needed
+scripts/manage-previews.sh down quinten
+
+# List all configured previews + pm2 status
+scripts/manage-previews.sh status
+```
+
+### How it works
+
+1. `up` creates a `git worktree` of the feature branch at `/srv/ubair-website-preview-<user>` (sibling to the main repo).
+2. The worktree's `public/api/static` is symlinked to the main dev repo's so the preview shows live CHPC data.
+3. A `.env` is created with `PORT=<preview port>` and `PREVIEW_MODE=true` (disables background refresh and report emails).
+4. `npm ci` installs dependencies, then `pm2 start ecosystem.config.cjs` launches the app.
+5. The pm2 app name is derived from the branch name by `ecosystem.config.cjs` — e.g. `basinwx-feature-braxton-sports`.
+
+### Adding a new user / preview
+
+Add an entry to `preview-apps.json` (choose a port not used by any other process — ops=3000, dev=3001, existing previews listed there), then open a PR.
+
+```json
+{ "user": "julianna", "branch": "feature/julianna-aviation", "port": 3003, "subdomain": "aviation" }
+```
+
+### Notes
+
+- Preview apps do **not** receive CHPC uploads — they read static data from the dev server's shared directory. Do not add a preview URL to `BASINWX_API_URLS`.
+- The feature branch must include the `PREVIEW_MODE` gate (merged from `dev`) for background jobs to be suppressed. Run `scripts/manage-previews.sh update <user>` after the branch syncs with dev.
+- Ports are hardcoded in `preview-apps.json`; update the file and the nginx vhost if you need to change a port.

--- a/preview-apps.json
+++ b/preview-apps.json
@@ -1,0 +1,8 @@
+[
+  {
+    "user": "quinten",
+    "branch": "feature/braxton-sports",
+    "port": 3002,
+    "subdomain": "sports"
+  }
+]

--- a/scripts/manage-previews.sh
+++ b/scripts/manage-previews.sh
@@ -63,10 +63,12 @@ cmd_up() {
   local user="$1"
   require_deploy_user
 
-  local branch port worktree_dir
+  local branch port subdomain worktree_dir
   branch=$(get_field "$user" branch)
   port=$(get_field "$user" port)
+  subdomain=$(get_field "$user" subdomain)
   worktree_dir=$(worktree_dir_for "$user")
+  local domain="${subdomain}.basinwx.dev"
 
   # Port sanity check
   if ss -tlnp 2>/dev/null | grep -q ":$port " || \
@@ -120,9 +122,11 @@ cmd_up() {
   echo "Installing npm dependencies..."
   npm ci --prefix "$worktree_dir" --silent
 
-  # Start pm2
+  # Start pm2 and persist the dump so the preview survives a reboot
+  # (the pm2 systemd unit only restores apps captured by the last `pm2 save`)
   echo "Starting pm2 app..."
   pm2 start "$worktree_dir/ecosystem.config.cjs"
+  pm2 save
 
   local pm2_name
   pm2_name=$(pm2_name_for_branch "$branch")
@@ -133,9 +137,9 @@ cmd_up() {
   echo "  worktree: $worktree_dir"
   echo ""
   echo "Next steps:"
-  echo "  1. Add nginx vhost:    $0 nginx $user | sudo tee /etc/nginx/sites-available/sports.basinwx.dev"
-  echo "  2. Enable + reload:    sudo ln -s /etc/nginx/sites-available/sports.basinwx.dev /etc/nginx/sites-enabled/ && sudo nginx -t && sudo systemctl reload nginx"
-  echo "  3. Obtain TLS cert:    sudo certbot certonly --nginx -d sports.basinwx.dev"
+  echo "  1. Add nginx vhost:    $0 nginx $user | sudo tee /etc/nginx/sites-available/$domain"
+  echo "  2. Enable + reload:    sudo ln -s /etc/nginx/sites-available/$domain /etc/nginx/sites-enabled/ && sudo nginx -t && sudo systemctl reload nginx"
+  echo "  3. Obtain TLS cert:    sudo certbot certonly --nginx -d $domain"
   echo "  4. Reload nginx again: sudo systemctl reload nginx"
 }
 
@@ -150,6 +154,8 @@ cmd_down() {
 
   echo "Stopping pm2 app: $pm2_name..."
   pm2 delete "$pm2_name" 2>/dev/null || echo "  (app not found in pm2 — already stopped?)"
+  # Refresh the saved dump so the deleted app isn't resurrected on reboot
+  pm2 save
 
   if [ -d "$worktree_dir" ]; then
     echo "Removing worktree: $worktree_dir..."

--- a/scripts/manage-previews.sh
+++ b/scripts/manage-previews.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# manage-previews.sh — spin up / tear down per-user branch preview apps.
+#
+# Each preview runs a git worktree of a feature branch on its own port,
+# served by nginx on <subdomain>.basinwx.dev. Configuration lives in
+# preview-apps.json at the repo root.
+#
+# Usage:
+#   scripts/manage-previews.sh up     <user>   # create worktree + start pm2
+#   scripts/manage-previews.sh down   <user>   # stop pm2 + remove worktree
+#   scripts/manage-previews.sh update <user>   # pull latest from origin
+#   scripts/manage-previews.sh nginx  <user>   # print nginx vhost snippet
+#   scripts/manage-previews.sh status          # list all preview apps
+#
+# Must be run as the 'deploy' user (same as the main pm2 process).
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="$REPO_DIR/preview-apps.json"
+WORKTREE_ROOT="/srv"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_deploy_user() {
+  [[ "$(whoami)" == "deploy" ]] || die "Run as the 'deploy' user (current: $(whoami))"
+}
+
+# Read a field from preview-apps.json for a given user via Node (avoids
+# reimplementing JSON parsing in shell and keeps logic consistent).
+get_field() {
+  local user="$1" field="$2"
+  node --input-type=module <<EOF
+import { readFileSync } from 'fs';
+const apps = JSON.parse(readFileSync('$CONFIG', 'utf8'));
+const app = apps.find(a => a.user === '$user');
+if (!app) { process.stderr.write('Unknown user: $user\n'); process.exit(1); }
+process.stdout.write(String(app['$field']));
+EOF
+}
+
+# Derive the pm2 app name the same way ecosystem.config.cjs does.
+pm2_name_for_branch() {
+  local branch="$1"
+  node --input-type=module <<EOF
+const branch = '$branch'
+  .replace(/[^A-Za-z0-9_-]/g, '-')
+  .replace(/-+/g, '-')
+  .replace(/^-+|-+\$/, '') || 'unknown';
+process.stdout.write('basinwx-' + branch);
+EOF
+}
+
+worktree_dir_for() {
+  echo "$WORKTREE_ROOT/ubair-website-preview-$1"
+}
+
+# ── subcommands ───────────────────────────────────────────────────────────────
+
+cmd_up() {
+  local user="$1"
+  require_deploy_user
+
+  local branch port worktree_dir
+  branch=$(get_field "$user" branch)
+  port=$(get_field "$user" port)
+  worktree_dir=$(worktree_dir_for "$user")
+
+  # Port sanity check
+  if ss -tlnp 2>/dev/null | grep -q ":$port " || \
+     netstat -tlnp 2>/dev/null | grep -q ":$port "; then
+    die "Port $port is already in use. Check 'ss -tlnp | grep $port' and choose a free port."
+  fi
+
+  # Create worktree if needed
+  if [ -d "$worktree_dir" ]; then
+    echo "Worktree already exists at $worktree_dir — skipping creation."
+  else
+    echo "Fetching origin..."
+    git -C "$REPO_DIR" fetch origin
+
+    echo "Creating worktree for $user (branch: $branch) at $worktree_dir..."
+    if git -C "$REPO_DIR" show-ref --verify --quiet "refs/heads/$branch"; then
+      # Local branch exists — use it directly
+      git -C "$REPO_DIR" worktree add "$worktree_dir" "$branch"
+    else
+      # Remote-only branch — create local tracking branch in worktree
+      git -C "$REPO_DIR" worktree add --track -b "$branch" "$worktree_dir" "origin/$branch"
+    fi
+  fi
+
+  # Symlink static data directory so preview shows real live data
+  local static_src="$REPO_DIR/public/api/static"
+  local static_dst="$worktree_dir/public/api/static"
+  if [ ! -L "$static_dst" ]; then
+    rm -rf "$static_dst"
+    ln -sf "$static_src" "$static_dst"
+    echo "Linked static data: $static_dst → $static_src"
+  fi
+
+  # Set up .env for this preview (copy from main, override PORT + PREVIEW_MODE)
+  if [ ! -f "$worktree_dir/.env" ]; then
+    echo "Copying .env and setting PORT=$port, PREVIEW_MODE=true..."
+    cp "$REPO_DIR/.env" "$worktree_dir/.env"
+    if grep -q '^PORT=' "$worktree_dir/.env"; then
+      sed -i "s/^PORT=.*/PORT=$port/" "$worktree_dir/.env"
+    else
+      echo "PORT=$port" >> "$worktree_dir/.env"
+    fi
+    if grep -q '^PREVIEW_MODE=' "$worktree_dir/.env"; then
+      sed -i "s/^PREVIEW_MODE=.*/PREVIEW_MODE=true/" "$worktree_dir/.env"
+    else
+      echo "PREVIEW_MODE=true" >> "$worktree_dir/.env"
+    fi
+  fi
+
+  # Install dependencies
+  echo "Installing npm dependencies..."
+  npm ci --prefix "$worktree_dir" --silent
+
+  # Start pm2
+  echo "Starting pm2 app..."
+  pm2 start "$worktree_dir/ecosystem.config.cjs"
+
+  local pm2_name
+  pm2_name=$(pm2_name_for_branch "$branch")
+  echo ""
+  echo "✓ Preview for '$user' is running."
+  echo "  pm2 app:  $pm2_name"
+  echo "  port:     $port"
+  echo "  worktree: $worktree_dir"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Add nginx vhost:    $0 nginx $user | sudo tee /etc/nginx/sites-available/sports.basinwx.dev"
+  echo "  2. Enable + reload:    sudo ln -s /etc/nginx/sites-available/sports.basinwx.dev /etc/nginx/sites-enabled/ && sudo nginx -t && sudo systemctl reload nginx"
+  echo "  3. Obtain TLS cert:    sudo certbot certonly --nginx -d sports.basinwx.dev"
+  echo "  4. Reload nginx again: sudo systemctl reload nginx"
+}
+
+cmd_down() {
+  local user="$1"
+  require_deploy_user
+
+  local branch worktree_dir pm2_name
+  branch=$(get_field "$user" branch)
+  worktree_dir=$(worktree_dir_for "$user")
+  pm2_name=$(pm2_name_for_branch "$branch")
+
+  echo "Stopping pm2 app: $pm2_name..."
+  pm2 delete "$pm2_name" 2>/dev/null || echo "  (app not found in pm2 — already stopped?)"
+
+  if [ -d "$worktree_dir" ]; then
+    echo "Removing worktree: $worktree_dir..."
+    git -C "$REPO_DIR" worktree remove "$worktree_dir" --force
+  else
+    echo "  (worktree not found at $worktree_dir — already removed?)"
+  fi
+
+  echo "✓ Preview for '$user' stopped."
+}
+
+cmd_update() {
+  local user="$1"
+  require_deploy_user
+
+  local branch worktree_dir pm2_name
+  branch=$(get_field "$user" branch)
+  worktree_dir=$(worktree_dir_for "$user")
+  pm2_name=$(pm2_name_for_branch "$branch")
+
+  [ -d "$worktree_dir" ] || die "Worktree not found. Run '$0 up $user' first."
+
+  echo "Fetching latest for $branch..."
+  git -C "$REPO_DIR" fetch origin
+  git -C "$worktree_dir" reset --hard "origin/$branch"
+
+  echo "Updating npm dependencies..."
+  npm ci --prefix "$worktree_dir" --silent
+
+  echo "Restarting pm2 app: $pm2_name..."
+  pm2 restart "$pm2_name"
+
+  echo "✓ Preview for '$user' updated to latest origin/$branch."
+}
+
+cmd_nginx() {
+  local user="$1"
+  local port subdomain
+  port=$(get_field "$user" port)
+  subdomain=$(get_field "$user" subdomain)
+  local domain="${subdomain}.basinwx.dev"
+
+  cat <<NGINX
+# nginx vhost for preview: $domain → port $port
+# ------------------------------------------------------
+# 1. Save:    $0 nginx $user | sudo tee /etc/nginx/sites-available/$domain
+# 2. Enable:  sudo ln -s /etc/nginx/sites-available/$domain /etc/nginx/sites-enabled/
+# 3. Test:    sudo nginx -t && sudo systemctl reload nginx
+# 4. Cert:    sudo certbot certonly --nginx -d $domain
+# 5. Reload:  sudo systemctl reload nginx
+
+server {
+    listen 80;
+    server_name $domain;
+    return 301 https://\$server_name\$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name $domain;
+
+    ssl_certificate     /etc/letsencrypt/live/$domain/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/$domain/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass         http://127.0.0.1:$port;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade \$http_upgrade;
+        proxy_set_header   Connection 'upgrade';
+        proxy_set_header   Host \$host;
+        proxy_cache_bypass \$http_upgrade;
+    }
+}
+NGINX
+}
+
+cmd_status() {
+  echo "=== Configured preview apps (preview-apps.json) ==="
+  node --input-type=module <<'EOF'
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+const config = resolve(process.env.REPO_DIR, 'preview-apps.json');
+const apps = JSON.parse(readFileSync(config, 'utf8'));
+for (const a of apps) {
+  const slug = a.branch.replace(/[^A-Za-z0-9_-]/g, '-').replace(/-+/g, '-').replace(/^-+|-+$/, '');
+  console.log(`  ${a.user.padEnd(12)} branch=${a.branch}  port=${a.port}  subdomain=${a.subdomain}.basinwx.dev  pm2=basinwx-${slug}`);
+}
+EOF
+  echo ""
+  echo "=== pm2 preview apps ==="
+  pm2 list --no-color 2>/dev/null | grep -E "basinwx-(feature|preview|quinten|braxton|julianna)" || echo "  (none running)"
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+export REPO_DIR="$REPO_DIR"
+
+case "${1:-}" in
+  up)     [[ -n "${2:-}" ]] || die "Usage: $0 up <user>"; cmd_up "$2" ;;
+  down)   [[ -n "${2:-}" ]] || die "Usage: $0 down <user>"; cmd_down "$2" ;;
+  update) [[ -n "${2:-}" ]] || die "Usage: $0 update <user>"; cmd_update "$2" ;;
+  nginx)  [[ -n "${2:-}" ]] || die "Usage: $0 nginx <user>"; cmd_nginx "$2" ;;
+  status) cmd_status ;;
+  *) echo "Usage: $0 {up|down|update|nginx|status} [user]"; exit 1 ;;
+esac

--- a/server/routes/trafficEvents.js
+++ b/server/routes/trafficEvents.js
@@ -2,7 +2,11 @@ import express from 'express';
 import TrafficEventsService from '../trafficEventsService.js';
 
 const router = express.Router();
-const trafficEventsService = new TrafficEventsService();
+let trafficEventsService = new TrafficEventsService();
+
+export function setTrafficEventsService(service) {
+    trafficEventsService = service;
+}
 
 // Get all traffic events for Uintah Basin
 router.get('/traffic-events', async (req, res) => {

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,7 @@ import { createServer } from 'http';
 // JRL - this is the data route
 import dataUploadRoutes from './routes/dataUpload.js';
 import roadWeatherRoutes, { setRoadWeatherService } from './routes/roadWeather.js';
-import trafficEventsRoutes from './routes/trafficEvents.js';
+import trafficEventsRoutes, { setTrafficEventsService } from './routes/trafficEvents.js';
 import synopticAPIRoutes from './routes/synopticAPI.js';
 import BackgroundRefreshService from './backgroundRefresh.js';
 import analyticsMiddleware, { getAnalyticsStats } from './middleware/analytics.js';
@@ -29,9 +29,10 @@ const reportEmailService = new ReportEmailService({
     getCameraStats: () => backgroundRefresh.cameraAnalysisScheduler.getStats()
 });
 
-// Share the roadWeatherService instance with routes
-// This ensures all routes use the same instance with camera analysis scheduler
+// Share service instances with routes so they use the background refresh's
+// shared cache and rate limiter, rather than creating their own.
 setRoadWeatherService(backgroundRefresh.roadWeatherService);
+setTrafficEventsService(backgroundRefresh.trafficEventsService);
 
 // Only parse JSON for application/json content-type (skip multipart/form-data uploads)
 app.use(express.json({ type: 'application/json' }));

--- a/server/server.js
+++ b/server/server.js
@@ -193,9 +193,13 @@ server.listen(PORT, () => {
     console.log('Data upload API available at /api/data/upload/:dataType');
     console.log('');
 
-    // Start background UDOT API refresh
-    backgroundRefresh.start();
-    reportEmailService.start();
+    // Skip background jobs for preview instances (feature-branch worktrees)
+    if (process.env.PREVIEW_MODE === 'true') {
+        console.log('PREVIEW_MODE=true — background refresh and report emails disabled.');
+    } else {
+        backgroundRefresh.start();
+        reportEmailService.start();
+    }
 });
 
 let isShuttingDown = false;


### PR DESCRIPTION
## Summary

Adds lightweight infrastructure for running a developer's feature branch as a live preview at its own subdomain (e.g. `sports.basinwx.dev`) without disturbing the main `dev` deployment. Extensible — adding a new user is one JSON entry + one nginx vhost.

## Files changed

| File | What |
|------|------|
| `preview-apps.json` | Config: one entry per user (branch, port, subdomain). **Add entries here to register new previews.** |
| `scripts/manage-previews.sh` | Shell script: `up`, `down`, `update`, `nginx`, `status` subcommands |
| `server/server.js` | Skip background refresh + report emails when `PREVIEW_MODE=true` |
| `.env.example` | Documents `PREVIEW_MODE` variable |
| `docs/DEPLOYMENT.md` | Section 9: full workflow |

## How to activate Quinten's sports preview

After merging this PR to dev (and Quinten syncing dev into their branch):

```bash
scripts/manage-previews.sh up quinten
scripts/manage-previews.sh nginx quinten | sudo tee /etc/nginx/sites-available/sports.basinwx.dev
sudo ln -s /etc/nginx/sites-available/sports.basinwx.dev /etc/nginx/sites-enabled/
sudo nginx -t && sudo systemctl reload nginx
sudo certbot certonly --nginx -d sports.basinwx.dev
sudo systemctl reload nginx
```

Preview reads live data from dev's `public/api/static` via symlink — no CHPC changes needed.

## Adding future users

```json
{ "user": "julianna", "branch": "feature/julianna-aviation", "port": 3003, "subdomain": "aviation" }
```

Add to `preview-apps.json`, open PR. Done.