### PR TITLE
feat(aviation): minimal HRRR KVEL crosswind consumer

### DIFF
--- a/public/css/aviation.css
+++ b/public/css/aviation.css
@@ -599,3 +599,28 @@ body[data-page-type="aviation"] h1::after {
     border-radius: 4px;
     font-size: 0.9rem;
 }
+/* HRRR crosswind preview table (brc-tools feed) */
+.crosswind-preview .init-time {
+    font-size: 0.85rem;
+    color: var(--aviation-secondary);
+    margin: 0 0 0.75rem 0;
+}
+.crosswind-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+.crosswind-table th,
+.crosswind-table td {
+    padding: 0.4rem 0.6rem;
+    text-align: right;
+    border-bottom: 1px solid rgba(30, 64, 175, 0.1);
+}
+.crosswind-table th:first-child,
+.crosswind-table td:first-child {
+    text-align: left;
+    font-family: 'Courier New', monospace;
+}
+.crosswind-table thead {
+    background: rgba(30, 64, 175, 0.06);
+}

--- a/public/js/aviation.js
+++ b/public/js/aviation.js
@@ -1,0 +1,101 @@
+// Aviation page — minimal HRRR crosswind consumer.
+//
+// Reads the latest forecast_hrrr_kvel_crosswind_*.json pushed by brc-tools
+// (stages A/B/C of the HRRR -> BasinWX rollout) and renders a simple
+// runway-relative wind table. Non-invasive: if no data is available the
+// rest of the aviation page (including its Coming Soon overlay) is
+// untouched.
+
+const API_FORECASTS = '/api/static/forecasts';
+const API_FILELIST = '/api/filelist/forecasts';
+const KVEL_PREFIX = 'forecast_hrrr_kvel_crosswind_';
+
+async function fetchLatestCrosswindPayload() {
+    const res = await fetch(API_FILELIST, { cache: 'no-store' });
+    if (!res.ok) return null;
+    const files = await res.json();
+    const matches = (files || [])
+        .filter(name => typeof name === 'string' && name.startsWith(KVEL_PREFIX) && name.endsWith('.json'))
+        .sort()
+        .reverse();
+    if (matches.length === 0) return null;
+    const payloadRes = await fetch(`${API_FORECASTS}/${matches[0]}`, { cache: 'no-store' });
+    if (!payloadRes.ok) return null;
+    return payloadRes.json();
+}
+
+function formatTime(iso) {
+    const d = new Date(iso);
+    return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}Z`;
+}
+
+function buildTable(payload) {
+    const series = payload.series || {};
+    const runways = payload.runway_headings_deg || [];
+    const rows = (payload.valid_times || []).map((iso, idx) => {
+        const cells = [formatTime(iso)];
+        cells.push(fmt(series.wind_speed_kt?.[idx], 0));
+        cells.push(fmt(series.wind_dir_deg?.[idx], 0));
+        for (const heading of runways) {
+            const tag = String(heading).padStart(3, '0');
+            cells.push(fmt(series[`headwind_kt_${tag}`]?.[idx], 0));
+            cells.push(fmt(series[`crosswind_kt_${tag}`]?.[idx], 0));
+        }
+        return cells;
+    });
+
+    const headers = ['Time (UTC)', 'Wind kt', 'Dir°'];
+    for (const heading of runways) {
+        const rwy = String(Math.round(heading / 10)).padStart(2, '0');
+        headers.push(`HW Rwy${rwy}`);
+        headers.push(`XW Rwy${rwy}`);
+    }
+
+    const table = document.createElement('table');
+    table.className = 'crosswind-table';
+    const thead = document.createElement('thead');
+    thead.innerHTML = `<tr>${headers.map(h => `<th>${h}</th>`).join('')}</tr>`;
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    for (const row of rows) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = row.map(c => `<td>${c}</td>`).join('');
+        tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    return table;
+}
+
+function fmt(value, decimals) {
+    if (value === null || value === undefined || Number.isNaN(value)) return '—';
+    return Number(value).toFixed(decimals);
+}
+
+function mountCrosswindSection(payload) {
+    const container = document.querySelector('.forecast-container') || document.querySelector('.content');
+    if (!container) return;
+
+    const section = document.createElement('section');
+    section.className = 'forecast-section crosswind-preview';
+    section.innerHTML = `
+        <h2><i class="fas fa-plane"></i> KVEL Runway Winds (HRRR ${payload.product === 'aviation_crosswind' ? payload.model : 'hrrr'})</h2>
+        <p class="init-time">Init ${payload.init_time} • runways ${(payload.runway_headings_deg || []).join('/')}° true</p>
+    `;
+    section.appendChild(buildTable(payload));
+    container.appendChild(section);
+}
+
+async function initAviation() {
+    try {
+        const payload = await fetchLatestCrosswindPayload();
+        if (payload) mountCrosswindSection(payload);
+    } catch (err) {
+        console.warn('aviation: crosswind payload fetch failed', err);
+    }
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAviation);
+} else {
+    initAviation();
+}


### PR DESCRIPTION
## Summary
Fills in the previously-empty `public/js/aviation.js` with a minimal consumer for `forecast_hrrr_kvel_crosswind_*.json`, the payload brc-tools Stage C ([brc-tools PR #20](https://github.com/Bingham-Research-Center/brc-tools/pull/20)) will push to `/api/static/forecasts`.

- Discovers the latest payload via `/api/filelist/forecasts` + the `forecast_hrrr_kvel_crosswind_` filename prefix.
- Appends one `<section class="forecast-section crosswind-preview">` inside the existing `.forecast-container` with a simple table: `time | wind_speed_kt | wind_dir_deg | headwind_kt_NNN | crosswind_kt_NNN` per runway heading.
- Non-invasive: if no payload exists yet, the script renders nothing and the Coming Soon overlay / existing placeholders stay exactly as they are.
- Small CSS block appended to `public/css/aviation.css` for the table.

Targets `dev` only — deliberately minimum-viable so brc-tools Stage C can be exercised end-to-end on basinwx.dev while the full aviation page is still being designed.

## Why now
brc-tools Stage C is blocked on "something on the website reads this JSON." This PR unblocks that without committing the final aviation UI.

## Test plan
- [ ] After brc-tools PR #20 ships and a first `forecast_hrrr_kvel_crosswind_*.json` lands in the `forecasts` bucket on `.dev`, load `https://basinwx.dev/aviation` and confirm the runway-winds table appears at the bottom of the forecast container.
- [ ] Before data lands: reload `.dev` and confirm no console errors, no rendered section, Coming Soon overlay intact.
- [ ] Open in mobile width; table overflows gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)