### PR TITLE
feat(roads): port auto-cycle cameras toggle to modular RoadWeatherMap

### DIFF
--- a/public/css/roads.css
+++ b/public/css/roads.css
@@ -2155,3 +2155,83 @@ body[data-page-type="roads"] .leaflet-drag-target {
         padding: 2px 8px;
     }
 }
+
+/* Auto-cycle cameras toggle (roads map) */
+.camera-cycle-control {
+    background: rgba(255, 255, 255, 0.98) !important;
+    backdrop-filter: blur(10px);
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+    border: 2px solid var(--roads-primary);
+    margin-top: 10px;
+    margin-left: 10px;
+}
+
+.camera-cycle-container {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.camera-cycle-label {
+    color: var(--roads-primary);
+    font-weight: 600;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    margin: 0;
+}
+
+.camera-cycle-switch {
+    width: 60px;
+    height: 30px;
+    background: #ddd;
+    border-radius: 15px;
+    position: relative;
+    cursor: pointer;
+    transition: background 0.3s ease;
+    border: 2px solid var(--roads-primary);
+}
+
+.camera-cycle-switch:hover {
+    background: #bbb;
+}
+
+.camera-cycle-switch.active {
+    background: var(--roads-primary);
+}
+
+.camera-cycle-slider {
+    width: 24px;
+    height: 24px;
+    background: white;
+    border-radius: 50%;
+    position: absolute;
+    top: 1px;
+    left: 1px;
+    transition: transform 0.3s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+}
+
+.camera-cycle-switch.active .camera-cycle-slider {
+    transform: translateX(30px);
+}
+
+.camera-cycle-timer-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(45deg, #ff4444, #cc0000);
+    border-radius: 50%;
+    transform: scale(0);
+    opacity: 0.7;
+}
+
+@keyframes camera-cycle-timer {
+    0% { transform: scale(0); }
+    50% { transform: scale(0.8); }
+    100% { transform: scale(1); }
+}

--- a/public/js/roads/RoadWeatherMap.js
+++ b/public/js/roads/RoadWeatherMap.js
@@ -30,10 +30,15 @@ class RoadWeatherMap {
         this.refreshTimer = null;
         this.weatherStationsVisible = false;
         this.experimentalRoadMode = false;
+
+        this.cameraCycleActive = false;
+        this.cameraCycleInterval = null;
+        this.cameraCycleIndex = 0;
     }
 
     init() {
         this.initMap();
+        this.setupCameraCycleControl();
         this.addLegend();
         this.loadRoadWeatherData();
         this.loadTrafficEvents();
@@ -739,6 +744,70 @@ class RoadWeatherMap {
             95: 'Thunderstorm', 96: 'Thunderstorm with Light Hail', 99: 'Thunderstorm with Heavy Hail'
         };
         return weatherCodes[code] || 'Unknown';
+    }
+
+    setupCameraCycleControl() {
+        const control = L.control({ position: 'topleft' });
+
+        control.onAdd = () => {
+            const div = L.DomUtil.create('div', 'camera-cycle-control');
+            div.innerHTML = `
+                <div class="camera-cycle-container">
+                    <label class="camera-cycle-label">Auto-cycle cameras:</label>
+                    <div class="camera-cycle-switch" id="camera-cycle-toggle">
+                        <div class="camera-cycle-slider">
+                            <div class="camera-cycle-timer-fill" id="camera-cycle-timer-fill"></div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            L.DomEvent.disableClickPropagation(div);
+            L.DomEvent.disableScrollPropagation(div);
+            return div;
+        };
+
+        control.addTo(this.map);
+
+        const toggle = document.getElementById('camera-cycle-toggle');
+        const timerFill = document.getElementById('camera-cycle-timer-fill');
+        if (!toggle) return;
+
+        toggle.addEventListener('click', () => {
+            this.cameraCycleActive = !this.cameraCycleActive;
+            if (this.cameraCycleActive) {
+                toggle.classList.add('active');
+                if (timerFill) timerFill.style.animation = 'camera-cycle-timer 8s linear infinite';
+                this.startCameraCycle();
+            } else {
+                toggle.classList.remove('active');
+                if (timerFill) timerFill.style.animation = 'none';
+                this.stopCameraCycle();
+            }
+        });
+    }
+
+    startCameraCycle() {
+        const visible = Array.from(this.cameraMarkers.values()).filter(m => this.map.hasLayer(m));
+        if (visible.length === 0) return;
+
+        this.cameraCycleIndex = 0;
+        visible[0].openPopup();
+
+        this.cameraCycleInterval = setInterval(() => {
+            const current = Array.from(this.cameraMarkers.values()).filter(m => this.map.hasLayer(m));
+            if (current.length === 0) return;
+            this.map.closePopup();
+            this.cameraCycleIndex = (this.cameraCycleIndex + 1) % current.length;
+            current[this.cameraCycleIndex].openPopup();
+        }, 8000);
+    }
+
+    stopCameraCycle() {
+        if (this.cameraCycleInterval) {
+            clearInterval(this.cameraCycleInterval);
+            this.cameraCycleInterval = null;
+        }
+        this.map.closePopup();
     }
 
     addLegend() {


### PR DESCRIPTION
Ports #175 (Michael's auto-cycle cameras feature) to the modular roads stack.

The original PR targeted `public/js/roads.js` which no longer exists on `dev` (split into `public/js/roads/` modules during the refactor). This PR applies the identical feature to `public/js/roads/RoadWeatherMap.js`.

**Changes:**
- Constructor: adds `cameraCycleActive`, `cameraCycleInterval`, `cameraCycleIndex`
- `init()`: calls `setupCameraCycleControl()`  
- New methods: `setupCameraCycleControl()`, `startCameraCycle()`, `stopCameraCycle()`
- `public/css/roads.css`: camera-cycle toggle styles (identical to #175)

Closes #175

Co-authored-by: MichaelJosephDavies <138522523+MichaelJosephDavies@users.noreply.github.com>