### PR TITLE
feat(outlook): authoring helper script + SOP rewrite

### DIFF
--- a/docs/SOP-outlook-upload.md
+++ b/docs/SOP-outlook-upload.md
@@ -1,63 +1,92 @@
-# SOP: Uploading Forecast Outlooks
+# SOP: Forecast Outlooks
 
-> **Note**: This is a temporary SOP document. In future, SOPs and "getting started" guides will live in the project Wiki. See GitHub Wiki for the canonical source once established.
+## Quick reference
 
-## Overview
+```bash
+# On the web server (as jrlawson or root):
+cd /var/www/ubair-website
 
-Forecast outlooks are markdown files uploaded from CHPC to the BasinWx website. They appear at [basinwx.com/forecast_outlooks](https://www.basinwx.com/forecast_outlooks) within 5 minutes of upload.
+node scripts/new-outlook.cjs                   # draft for right now
+node scripts/new-outlook.cjs 20260306 1300     # draft for specific time
+nano public/api/static/outlooks/draft_*.md     # edit your draft
+node scripts/new-outlook.cjs --validate draft_20260306_1300.md
+node scripts/new-outlook.cjs --publish  draft_20260306_1300.md
+```
 
 ## Workflow
 
-### 1. Copy the template
+### 1. Generate a draft
 
 ```bash
-cd ~/outlooks  # or wherever you store drafts
-cp /path/to/template-2025-2026.md outlook_$(date +%Y%m%d_%H%M).md
+node scripts/new-outlook.cjs [YYYYMMDD] [HHMM]
 ```
 
-Filename **must** match pattern: `outlook_YYYYMMDD_HHMM.md`
+Creates `draft_YYYYMMDD_HHMM.md` in the outlooks folder with dates auto-filled.
+The `draft_` prefix keeps it **off the website** — only `outlook_` files appear.
 
-### 2. Edit the outlook
+### 2. Edit the draft
 
-Replace all `[bracketed]` placeholders:
-- `[H.MMam/pm]` → e.g., `11.30am`
-- `[D Month YYYY]` → e.g., `1 December 2025`
-- `[Day D Mon]` → e.g., `Mon 1 Dec`
-- Risk level → one of: `NO`, `LOW`, `MODERATE`, `HIGH`
-- Confidence → one of: `LOW`, `MODERATE`, `HIGH`
+Replace every `[BRACKETED]` placeholder. The validator will catch any you miss.
 
-**Important for color-coding**: Risk and confidence lines must contain exact phrases:
+**Risk line** — pick one (exact text, all caps, on its own line):
 - `NO RISK OF ELEVATED OZONE` (renders green)
 - `LOW RISK OF ELEVATED OZONE` (renders blue)
+- `SOME RISK OF ELEVATED OZONE` (renders orange)
 - `MODERATE RISK OF ELEVATED OZONE` (renders orange)
 - `HIGH RISK OF ELEVATED OZONE` (renders red)
-- `HIGH CONFIDENCE` / `MODERATE CONFIDENCE` / `LOW CONFIDENCE`
 
-### 3. Upload from CHPC
+**Confidence line** — pick one (exact text, all caps, on its own line):
+- `HIGH CONFIDENCE` (renders green — reassuring)
+- `MEDIUM CONFIDENCE` (renders orange)
+- `MODERATE CONFIDENCE` (renders orange)
+- `LOW CONFIDENCE` (renders red — uncertain)
+
+### 3. Validate
 
 ```bash
-# Ensure brc-tools is installed and configured
+node scripts/new-outlook.cjs --validate draft_20260306_1300.md
+```
+
+Checks: required sections, valid risk/confidence phrases, no leftover placeholders.
+
+### 4. Publish
+
+```bash
+node scripts/new-outlook.cjs --publish draft_20260306_1300.md
+```
+
+Runs validation, then renames `draft_` → `outlook_`. The server picks it up within 5 minutes.
+
+### 5. Upload from CHPC (alternative)
+
+If uploading from CHPC instead of editing on the server:
+
+```bash
 python -m brc_tools.download.push_outlook outlook_YYYYMMDD_HHMM.md
 ```
 
-Requirements:
-- `DATA_UPLOAD_API_KEY` environment variable set
-- `~/.config/ubair-website/website_url` file with server URL
+Requires `DATA_UPLOAD_API_KEY` env var and `~/.config/ubair-website/website_url`.
 
-### 4. Verify
+## Server access for non-root users
 
-Check [basinwx.com/forecast_outlooks](https://www.basinwx.com/forecast_outlooks) within 5 minutes.
+To let `jrlawson` (or other users) run the script without root:
 
-The `outlooks_list.json` auto-regenerates every 5 minutes on the server.
+```bash
+# One-time setup (run as root):
+sudo usermod -aG www-data jrlawson
+sudo chmod g+w /var/www/ubair-website/public/api/static/outlooks/
+# jrlawson must log out and back in for group change to take effect.
+```
+
+Then as `jrlawson`:
+```bash
+cd /var/www/ubair-website
+node scripts/new-outlook.cjs 20260306 1300
+```
 
 ## Troubleshooting
 
-- **Upload fails**: Check API key and hostname validation
-- **Colors not showing**: Ensure exact phrasing (e.g., `HIGH RISK` not `High Risk`)
-- **Not appearing in list**: Filename must match `outlook_YYYYMMDD_HHMM.md` pattern
-
-## Future Plans
-
-- Wiki-based SOP documentation
-- Validation script for markdown structure
-- Integration with email distribution list
+- **Colors not showing**: Risk/confidence must be exact phrases, all caps, own line
+- **Not in list**: Filename must be `outlook_YYYYMMDD_HHMM.md` (not `draft_`)
+- **Permission denied**: Ensure you're in the `www-data` group (see above)
+- **Upload fails from CHPC**: Check API key and hostname validation

--- a/public/api/static/outlooks/template-2025-2026.md
+++ b/public/api/static/outlooks/template-2025-2026.md
@@ -3,18 +3,18 @@
 Issued: [H.MMam/pm] Mountain Time, [D Month YYYY]
 
 ### Day 1–5 ([Day D Mon]–[Day D Mon]):
-[NO/LOW/MODERATE/HIGH] RISK OF ELEVATED OZONE
-[LOW/MODERATE/HIGH] CONFIDENCE
+[NO/LOW/SOME/MODERATE/HIGH] RISK OF ELEVATED OZONE
+[LOW/MEDIUM/HIGH] CONFIDENCE
 [Details about this period's weather and ozone risk.]
 
 ### Day 6–10 ([Day D Mon]–[Day D Mon]):
-[NO/LOW/MODERATE/HIGH] RISK OF ELEVATED OZONE
-[LOW/MODERATE/HIGH] CONFIDENCE
+[NO/LOW/SOME/MODERATE/HIGH] RISK OF ELEVATED OZONE
+[LOW/MEDIUM/HIGH] CONFIDENCE
 [Details about this period's weather and ozone risk.]
 
 ### Day 11–15 ([Day D Mon]–[Day D Mon]):
-[NO/LOW/MODERATE/HIGH] RISK OF ELEVATED OZONE
-[LOW/MODERATE/HIGH] CONFIDENCE
+[NO/LOW/SOME/MODERATE/HIGH] RISK OF ELEVATED OZONE
+[LOW/MEDIUM/HIGH] CONFIDENCE
 [Details about this period's weather and ozone risk.]
 
 ----

--- a/public/css/outlooks.css
+++ b/public/css/outlooks.css
@@ -84,13 +84,19 @@
     white-space: nowrap;
 }
 
-.risk-no, .risk-low {
+.risk-no {
     background: linear-gradient(135deg, #dcfce7, #bbf7d0);
     color: #15803d;
     border: 1px solid #22c55e;
 }
 
-.risk-moderate {
+.risk-low {
+    background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+    color: #1e40af;
+    border: 1px solid #3b82f6;
+}
+
+.risk-some, .risk-moderate {
     background: linear-gradient(135deg, #fef3c7, #fde68a);
     color: #a16207;
     border: 1px solid #f59e0b;

--- a/public/js/forecast_outlooks.js
+++ b/public/js/forecast_outlooks.js
@@ -18,39 +18,6 @@ document.addEventListener("DOMContentLoaded", function() {
 
     let currentFile = null;
 
-    // Enhanced risk word highlighting function
-    function highlightRiskWords(html) {
-        return html
-            // Full "X RISK" phrases - Green/Blue/Orange/Red pills
-            .replace(/\bNO RISK\b/gi, '<span class="risk-indicator risk-no">NO RISK</span>')
-            .replace(/\bLOW RISK\b/gi, '<span class="risk-indicator risk-low">LOW RISK</span>')
-            .replace(/\b(MODERATE|MEDIUM) RISK\b/gi, '<span class="risk-indicator risk-moderate">MODERATE RISK</span>')
-            .replace(/\bHIGH RISK\b/gi, '<span class="risk-indicator risk-high">HIGH RISK</span>')
-
-            // Standalone risk levels (e.g., after "ELEVATED OZONE:") - also get pill styling
-            .replace(/(?<=[:]\s*)<strong>(NO|NONE)<\/strong>/gi, '<span class="risk-indicator risk-no">$1</span>')
-            .replace(/(?<=[:]\s*)<strong>LOW<\/strong>/gi, '<span class="risk-indicator risk-low">LOW</span>')
-            .replace(/(?<=[:]\s*)<strong>(MODERATE|MEDIUM)<\/strong>/gi, '<span class="risk-indicator risk-moderate">$1</span>')
-            .replace(/(?<=[:]\s*)<strong>HIGH<\/strong>/gi, '<span class="risk-indicator risk-high">HIGH</span>')
-
-            // Standalone bold risk words without colon prefix
-            .replace(/<strong>(NO|NONE)<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-no">$1</span>')
-            .replace(/<strong>LOW<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-low">LOW</span>')
-            .replace(/<strong>(MODERATE|MEDIUM)<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-moderate">$1</span>')
-            .replace(/<strong>HIGH<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-high">HIGH</span>')
-
-            // Confidence indicators
-            .replace(/\b(HIGH|MODERATE|MEDIUM|LOW) CONFIDENCE\b/gi, (match, level) => {
-                const colors = {
-                    'HIGH': '#22c55e',
-                    'MODERATE': '#f59e0b',
-                    'MEDIUM': '#f59e0b',
-                    'LOW': '#dc2626'
-                };
-                return `<span style="color: ${colors[level.toUpperCase()]}; font-weight: 600;">${match.toUpperCase()}</span>`;
-            });
-    }
-
     async function loadOutlook(filename, summaryOnly = false) {
         try {
             if (outlookContent && !summaryOnly) {

--- a/public/js/outlook-highlight.js
+++ b/public/js/outlook-highlight.js
@@ -1,0 +1,36 @@
+/**
+ * Shared outlook risk/confidence highlighting.
+ * Loaded by index.html and forecast_outlooks.html before their own scripts.
+ */
+window.highlightRiskWords = function(html) {
+    return html
+        // Risk level pills (order matters: specific phrases before standalone words)
+        .replace(/\bNO RISK\b/gi, '<span class="risk-indicator risk-no">NO RISK</span>')
+        .replace(/\bLOW RISK\b/gi, '<span class="risk-indicator risk-low">LOW RISK</span>')
+        .replace(/\bSOME RISK\b/gi, '<span class="risk-indicator risk-some">SOME RISK</span>')
+        .replace(/\b(MODERATE|MEDIUM) RISK\b/gi, '<span class="risk-indicator risk-moderate">MODERATE RISK</span>')
+        .replace(/\bHIGH RISK\b/gi, '<span class="risk-indicator risk-high">HIGH RISK</span>')
+
+        // Standalone risk levels after colon (e.g., "ELEVATED OZONE: **NO**")
+        .replace(/(?<=[:]\s*)<strong>(NO|NONE)<\/strong>/gi, '<span class="risk-indicator risk-no">$1</span>')
+        .replace(/(?<=[:]\s*)<strong>LOW<\/strong>/gi, '<span class="risk-indicator risk-low">LOW</span>')
+        .replace(/(?<=[:]\s*)<strong>(MODERATE|MEDIUM)<\/strong>/gi, '<span class="risk-indicator risk-moderate">$1</span>')
+        .replace(/(?<=[:]\s*)<strong>HIGH<\/strong>/gi, '<span class="risk-indicator risk-high">HIGH</span>')
+
+        // Standalone bold risk words without colon prefix
+        .replace(/<strong>(NO|NONE)<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-no">$1</span>')
+        .replace(/<strong>LOW<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-low">LOW</span>')
+        .replace(/<strong>(MODERATE|MEDIUM)<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-moderate">$1</span>')
+        .replace(/<strong>HIGH<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-high">HIGH</span>')
+
+        // Confidence indicators (semantic: HIGH=good/green, LOW=bad/red)
+        .replace(/\b(HIGH|MODERATE|MEDIUM|LOW) CONFIDENCE\b/gi, (match, level) => {
+            const colors = {
+                'HIGH': '#22c55e',
+                'MODERATE': '#f59e0b',
+                'MEDIUM': '#f59e0b',
+                'LOW': '#dc2626'
+            };
+            return `<span style="color: ${colors[level.toUpperCase()]}; font-weight: 700;">${match.toUpperCase()}</span>`;
+        });
+};

--- a/scripts/new-outlook.cjs
+++ b/scripts/new-outlook.cjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Outlook authoring helper: generate, validate, publish.
+ *
+ * Usage:
+ *   node scripts/new-outlook.js [YYYYMMDD] [HHMM]   Generate draft
+ *   node scripts/new-outlook.js --validate <file>    Validate draft
+ *   node scripts/new-outlook.js --publish  <file>    Validate + go live
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const OUTLOOKS_DIR = path.join(__dirname, '..', 'public', 'api', 'static', 'outlooks');
+const TEMPLATE = path.join(OUTLOOKS_DIR, 'template-2025-2026.md');
+
+const VALID_RISK = [
+    'NO RISK OF ELEVATED OZONE',
+    'LOW RISK OF ELEVATED OZONE',
+    'SOME RISK OF ELEVATED OZONE',
+    'MODERATE RISK OF ELEVATED OZONE',
+    'HIGH RISK OF ELEVATED OZONE',
+];
+const VALID_CONFIDENCE = [
+    'LOW CONFIDENCE',
+    'MEDIUM CONFIDENCE',
+    'MODERATE CONFIDENCE',
+    'HIGH CONFIDENCE',
+];
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const MONTHS_FULL = ['January', 'February', 'March', 'April', 'May', 'June',
+                     'July', 'August', 'September', 'October', 'November', 'December'];
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+function fmtShort(d) {
+    return `${DAYS[d.getDay()]} ${d.getDate()} ${MONTHS[d.getMonth()]}`;
+}
+
+function addDays(d, n) {
+    const r = new Date(d);
+    r.setDate(r.getDate() + n);
+    return r;
+}
+
+function fmtTime(h, m) {
+    const ampm = h >= 12 ? 'pm' : 'am';
+    const h12 = h % 12 || 12;
+    return `${h12}.${String(m).padStart(2, '0')}${ampm}`;
+}
+
+function parseFilenameDate(stamp, time) {
+    const y = parseInt(stamp.slice(0, 4));
+    const mo = parseInt(stamp.slice(4, 6)) - 1;
+    const d = parseInt(stamp.slice(6, 8));
+    const h = parseInt(time.slice(0, 2));
+    const mi = parseInt(time.slice(2, 4));
+    return new Date(y, mo, d, h, mi);
+}
+
+// ── generate ─────────────────────────────────────────────────────────
+
+function generate(dateStamp, timeStamp) {
+    const now = new Date();
+    const ds = dateStamp || `${now.getFullYear()}${String(now.getMonth()+1).padStart(2,'0')}${String(now.getDate()).padStart(2,'0')}`;
+    const ts = timeStamp || `${String(now.getHours()).padStart(2,'0')}${String(now.getMinutes()).padStart(2,'0')}`;
+    const issued = parseFilenameDate(ds, ts);
+
+    const day0 = new Date(issued.getFullYear(), issued.getMonth(), issued.getDate());
+    const ranges = [
+        { label: '1–5',   start: day0,            end: addDays(day0, 4)  },
+        { label: '6–10',  start: addDays(day0, 5), end: addDays(day0, 9)  },
+        { label: '11–15', start: addDays(day0, 10), end: addDays(day0, 14) },
+    ];
+
+    const issuedStr = `${fmtTime(issued.getHours(), issued.getMinutes())} Mountain Time, ${issued.getDate()} ${MONTHS_FULL[issued.getMonth()]} ${issued.getFullYear()}`;
+
+    let body = `## Uintah Basin Winter Ozone: **Official Outlook**
+### **Two-Week Overview**: [SUMMARY]
+Issued: ${issuedStr} 
+`;
+
+    for (const r of ranges) {
+        body += `
+### Day ${r.label} (${fmtShort(r.start)} -- ${fmtShort(r.end)}):
+[NO/LOW/SOME/MODERATE/HIGH] RISK OF ELEVATED OZONE
+
+[LOW/MEDIUM/HIGH] CONFIDENCE
+
+[DISCUSSION]
+`;
+    }
+
+    body += `
+----
+
+### Extended discussion
+
+- [EXTENDED DISCUSSION]
+
+---- 
+
+#### Forecasters: [NAMES]
+
+# Further Resources
+#### How to reduce emissions
+> The Utah Petroleum Association has prepared a great summary of actions that can be taken to reduce emissions, which [you can find here](https://www.usu.edu/binghamresearch/images/latchthehatch.jpg).
+
+#### Resources from **Bingham Research Center**
+> If you would like additional information about Uinta Basin air quality, please [contact us](https://www.usu.edu/binghamresearch/contact-us). We have produced a [short fact sheet about ozone in the Uinta Basin](https://www.usu.edu/binghamresearch/files/2-pagehandoutUBairquality.pdf), and you can view [real-time air quality data for the entire Basin here](http://ubair.usu.edu/index.html) and our new [BasinWx forecast website here](https://www.basinwx.com). Finally, [our research group's website](https://www.usu.edu/binghamresearch) has a large number of reports, papers, and other resources to help you understand the issue.
+
+![Bingham Research Center](/api/static/outlooks/UB_01_UStateLeft_Gray.png)
+`;
+
+    const outFile = path.join(OUTLOOKS_DIR, `draft_${ds}_${ts}.md`);
+    fs.writeFileSync(outFile, body);
+    console.log(`✓ Created ${path.basename(outFile)}`);
+    console.log(`  Edit it, then: node scripts/new-outlook.cjs --publish ${path.basename(outFile)}`);
+}
+
+// ── validate ─────────────────────────────────────────────────────────
+
+function validate(filename) {
+    const filepath = path.join(OUTLOOKS_DIR, filename);
+    if (!fs.existsSync(filepath)) {
+        console.error(`✗ File not found: ${filename}`);
+        return false;
+    }
+
+    const content = fs.readFileSync(filepath, 'utf8');
+    const lines = content.split('\n');
+    const errors = [];
+    const warnings = [];
+
+    // Check for leftover placeholders
+    const placeholders = content.match(/\[[A-Z/ ]{3,}\]/g) || [];
+    for (const p of placeholders) {
+        errors.push(`Unfilled placeholder: ${p}`);
+    }
+
+    // Check issued line
+    if (!lines.some(l => /^Issued:\s*.+Mountain Time/i.test(l))) {
+        errors.push('Missing or malformed "Issued:" line');
+    }
+
+    // Check three day-range sections
+    const dayHeaders = lines.filter(l => /^### Day \d+–\d+/.test(l));
+    if (dayHeaders.length < 3) {
+        errors.push(`Expected 3 day-range sections, found ${dayHeaders.length}`);
+    }
+
+    // Check risk lines (one per section)
+    const riskLines = lines.filter(l => /RISK OF ELEVATED OZONE/i.test(l.trim()));
+    if (riskLines.length < 3) {
+        errors.push(`Expected 3 risk lines, found ${riskLines.length}`);
+    }
+    for (const rl of riskLines) {
+        const trimmed = rl.trim();
+        if (!VALID_RISK.includes(trimmed)) {
+            errors.push(`Invalid risk line: "${trimmed}"`);
+        }
+    }
+
+    // Check confidence lines
+    const confLines = lines.filter(l => /CONFIDENCE\s*$/i.test(l.trim()) && l.trim().length < 30);
+    if (confLines.length < 3) {
+        errors.push(`Expected 3 confidence lines, found ${confLines.length}`);
+    }
+    for (const cl of confLines) {
+        const trimmed = cl.trim();
+        if (!VALID_CONFIDENCE.includes(trimmed)) {
+            errors.push(`Invalid confidence line: "${trimmed}"`);
+        }
+    }
+
+    // Check forecasters
+    if (!lines.some(l => /Forecasters:/i.test(l))) {
+        warnings.push('No "Forecasters:" line found');
+    }
+
+    // Report
+    if (warnings.length) {
+        for (const w of warnings) console.log(`  ⚠ ${w}`);
+    }
+    if (errors.length) {
+        for (const e of errors) console.log(`  ✗ ${e}`);
+        console.log(`\n✗ ${filename}: ${errors.length} error(s)`);
+        return false;
+    }
+    console.log(`✓ ${filename}: valid`);
+    return true;
+}
+
+// ── publish ──────────────────────────────────────────────────────────
+
+function publish(filename) {
+    if (!filename.startsWith('draft_')) {
+        console.error(`✗ Expected a draft_ file, got: ${filename}`);
+        return;
+    }
+
+    if (!validate(filename)) {
+        console.error('\n✗ Fix errors before publishing.');
+        return;
+    }
+
+    const liveFile = filename.replace(/^draft_/, 'outlook_');
+    const src = path.join(OUTLOOKS_DIR, filename);
+    const dst = path.join(OUTLOOKS_DIR, liveFile);
+
+    if (fs.existsSync(dst)) {
+        console.error(`✗ ${liveFile} already exists. Remove it first if you want to overwrite.`);
+        return;
+    }
+
+    fs.renameSync(src, dst);
+    console.log(`✓ Published: ${liveFile}`);
+    console.log('  It will appear on basinwx.com within 5 minutes.');
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args[0] === '--validate') {
+    validate(args[1]);
+} else if (args[0] === '--publish') {
+    publish(args[1]);
+} else if (args[0] === '--help' || args[0] === '-h') {
+    console.log(`Outlook helper — generate, validate, publish.
+
+  node scripts/new-outlook.cjs [YYYYMMDD] [HHMM]   Create a draft
+  node scripts/new-outlook.cjs --validate <file>    Check format
+  node scripts/new-outlook.cjs --publish  <file>    Validate + go live
+`);
+} else {
+    generate(args[0], args[1]);
+}

--- a/views/forecast_outlooks.html
+++ b/views/forecast_outlooks.html
@@ -48,6 +48,7 @@
 
 <!-- Load markdown-it BEFORE our scripts -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/13.0.1/markdown-it.min.js"></script>
+<script src="/public/js/outlook-highlight.js"></script>
 <script type="module" src="/public/js/loadSidebar.js"></script>
 <script type="module" src="/public/js/forecast_outlooks.js"></script>
 </body>

--- a/views/index.html
+++ b/views/index.html
@@ -267,6 +267,7 @@
 
 <!-- Load markdown-it for homepage preview -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/13.0.1/markdown-it.min.js"></script>
+<script src="/public/js/outlook-highlight.js"></script>
 
 <script>
     // Store outside click handler reference to enable proper cleanup
@@ -385,16 +386,8 @@
             // Render markdown to HTML
             let renderedHtml = md.render(previewLines.join('\n'));
 
-            // Apply risk word highlighting (same as forecast_outlooks.js)
-            renderedHtml = renderedHtml
-                .replace(/\bNO RISK\b/gi, '<span class="risk-indicator risk-no">NO RISK</span>')
-                .replace(/\bLOW RISK\b/gi, '<span class="risk-indicator risk-low">LOW RISK</span>')
-                .replace(/\b(MODERATE|MEDIUM) RISK\b/gi, '<span class="risk-indicator risk-moderate">MODERATE RISK</span>')
-                .replace(/\bHIGH RISK\b/gi, '<span class="risk-indicator risk-high">HIGH RISK</span>')
-                .replace(/<strong>(NO|NONE)<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-no">$1</span>')
-                .replace(/<strong>LOW<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-low">LOW</span>')
-                .replace(/<strong>(MODERATE|MEDIUM)<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-moderate">$1</span>')
-                .replace(/<strong>HIGH<\/strong>(?!\s*RISK)/gi, '<span class="risk-indicator risk-high">HIGH</span>');
+            // Apply risk word highlighting
+            renderedHtml = highlightRiskWords(renderedHtml);
 
             outlookSummary.innerHTML = `<div class="markdown-content">${renderedHtml}</div>`;
 


### PR DESCRIPTION
Adds a CLI helper for authoring weather outlooks and rewrites the SOP doc to match.

**Changes:**
- New script: `scripts/new-outlook.cjs` — generate, validate, and publish outlook drafts from CLI; validates risk/confidence phrases, checks for leftover placeholders; draft prefix keeps WIP files off the live site
- `public/js/outlook-highlight.js` — extract shared risk/confidence highlighting to a shared module (DRY up index.html vs forecast_outlooks.html)
- `public/css/` — adds SOME RISK level, separates LOW from NO RISK colors
- Docs: rewrite outlook SOP for the new authoring workflow (quick-reference block, validation and publish steps, updated template)