### PR TITLE
feat(sports): stub page + navbar entry

### DIFF
--- a/public/css/sports.css
+++ b/public/css/sports.css
@@ -1,0 +1,100 @@
+/* Sports page */
+
+.sports-header {
+    padding: 2rem 2rem 0.5rem;
+}
+
+.sports-header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 0.4rem;
+    color: var(--primary-color, #1a3a5c);
+}
+
+.sports-subtitle {
+    color: #555;
+    font-size: 1.05rem;
+    margin: 0;
+}
+
+.draft-notice {
+    margin: 1.2rem 2rem;
+    padding: 0.75rem 1rem;
+    background: #fff8e1;
+    border-left: 4px solid #f59e0b;
+    border-radius: 4px;
+    font-size: 0.95rem;
+    color: #78400a;
+}
+
+.draft-notice a {
+    color: #1a3a5c;
+}
+
+.sports-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.25rem;
+    padding: 1rem 2rem 2rem;
+}
+
+.sports-card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 1.4rem;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.sports-card.draft {
+    border-color: #f59e0b;
+    background: #fffdf0;
+}
+
+.card-icon {
+    font-size: 1.8rem;
+    color: var(--primary-color, #1a3a5c);
+}
+
+.sports-card h2 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 0;
+    color: #1a3a5c;
+}
+
+.sports-card p {
+    font-size: 0.9rem;
+    color: #555;
+    margin: 0;
+    flex: 1;
+}
+
+.status-badge {
+    display: inline-block;
+    margin-top: 0.5rem;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    background: #e0e7ef;
+    color: #1a3a5c;
+    width: fit-content;
+}
+
+.draft-badge {
+    background: #fde68a;
+    color: #78400a;
+}
+
+@media (max-width: 640px) {
+    .sports-header,
+    .draft-notice,
+    .sports-grid {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+}

--- a/public/partials/sidebar.html
+++ b/public/partials/sidebar.html
@@ -27,6 +27,7 @@
                 <i class="fas fa-flask"></i> Coming Soon <i class="fas fa-chevron-down dropdown-arrow"></i>
             </a>
             <ul class="dropdown-menu">
+                <li><a href="/sports"><i class="fa-solid fa-baseball"></i> Sports</a></li>
                 <li><a href="/agriculture"><i class="fas fa-seedling"></i> Agriculture</a></li>
                 <li><a href="/aviation"><i class="fas fa-plane"></i> Aviation</a></li>
                 <li><a href="/water"><i class="fas fa-ship"></i> On The Water</a></li>

--- a/server/server.js
+++ b/server/server.js
@@ -81,6 +81,10 @@ app.get('/forecast_weather', (req, res) => {
     res.sendFile(path.join(__dirname, '../views/forecast_weather.html'));
 });
 
+app.get('/sports', (req, res) => {
+    res.sendFile(path.join(__dirname, '../views/sports.html'));
+});
+
 app.get('/agriculture', (req, res) => {
     res.sendFile(path.join(__dirname, '../views/agriculture.html'));
 });

--- a/views/sports.html
+++ b/views/sports.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Sports Weather for Uintah Basin — coming soon">
+    <title>BasinWx — Sports</title>
+    <link rel="icon" type="image/x-icon" href="/public/images/favicons/gemini-b2.ico">
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+
+    <!-- CSS -->
+    <link rel="stylesheet" href="/public/css/main.css">
+    <link rel="stylesheet" href="/public/css/sports.css">
+</head>
+<body data-page-type="sports">
+    <div class="colored-bar"></div>
+
+    <div class="sidebar_container"></div>
+
+    <div class="main-content">
+        <div class="sports-header">
+            <h1><i class="fa-solid fa-baseball"></i> Sports Weather</h1>
+            <p class="sports-subtitle">Weather conditions for outdoor sports and recreation in the Uintah Basin</p>
+        </div>
+
+        <!-- Draft notice -->
+        <div class="draft-notice">
+            <i class="fas fa-hard-hat"></i>
+            <strong>Under Construction</strong> — This page is a work in progress.
+            Ideas and feedback welcome on <a href="https://github.com/Bingham-Research-Center/ubair-website/pull/128" target="_blank" rel="noopener">GitHub PR #128</a>.
+        </div>
+
+        <!-- Planned sections — rough outline for discussion -->
+        <div class="sports-grid">
+
+            <div class="sports-card planned">
+                <div class="card-icon"><i class="fas fa-thermometer-half"></i></div>
+                <h2>Game Day Conditions</h2>
+                <p>Current temperature, feels-like, humidity, wind, and UV index at key venues and parks in the basin.</p>
+                <span class="status-badge">Planned</span>
+            </div>
+
+            <div class="sports-card planned">
+                <div class="card-icon"><i class="fas fa-cloud-rain"></i></div>
+                <h2>Rain / Field Playability</h2>
+                <p>Precipitation totals, soil saturation proxy, and a simple playability score for grass and turf fields.</p>
+                <span class="status-badge">Planned</span>
+            </div>
+
+            <div class="sports-card planned">
+                <div class="card-icon"><i class="fas fa-wind"></i></div>
+                <h2>Wind & Throwing Conditions</h2>
+                <p>Headwind/crosswind components, gust risk, and direction relative to common field orientations — useful for football, baseball, disc golf.</p>
+                <span class="status-badge">Planned</span>
+            </div>
+
+            <div class="sports-card planned">
+                <div class="card-icon"><i class="fas fa-sun"></i></div>
+                <h2>Heat Risk</h2>
+                <p>WBGT (wet bulb globe temperature) estimate, heat index, and activity advisories following NATA / NOAA thresholds.</p>
+                <span class="status-badge">Planned</span>
+            </div>
+
+            <div class="sports-card planned">
+                <div class="card-icon"><i class="fas fa-snowflake"></i></div>
+                <h2>Winter Sports</h2>
+                <p>Snow depth, new snow, temperature, and wind chill for local sledding hills and backcountry access points.</p>
+                <span class="status-badge">Planned</span>
+            </div>
+
+            <div class="sports-card draft">
+                <div class="card-icon"><i class="fas fa-dice"></i></div>
+                <h2>Weather Wager Game</h2>
+                <p>Prototype prediction game — guess tomorrow's high temp and win bragging rights. Based on Braxton's design in PR #128.</p>
+                <span class="status-badge draft-badge">Draft / Prototype</span>
+            </div>
+
+        </div>
+    </div>
+
+    <script src="/public/js/loadSidebar.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Unblocks the sports page on `dev` without the prototype code from #128 that isn't ready yet.

**What this does:**
- Adds **Sports** to the Coming Soon navbar dropdown
- Adds `GET /sports` route in `server.js`
- Creates `views/sports.html` — a clean card-grid outline of planned features
- Creates `public/css/sports.css`

**What it deliberately excludes from #128:**
- Wagering game prototype (not ready)
- Easter egg JS/CSS
- The `PORT=8000` change (would break staging)
- The ideas notes file

**Next steps for #128:**
Braxton / Quinten — your prototype work lives in `feature/braxton-sports`. Two options:
1. Rebase that branch onto `dev` (removing the PORT change), and open a new PR that adds just the wagering UI on top of this stub.
2. Or add your prototype directly to this `feat/sports-stub` branch before it merges.

Closes nothing — #128 stays open as the prototype development branch.
