### PR TITLE
chore(docs): trim CLAUDE.md + LLM-doc naming convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,102 +1,67 @@
-# Uintah Basin Air Quality Website - Claude Context
+# Uintah Basin Air Quality Website — Claude Context
 
-## Project Overview
-Weather data visualization website showing live air quality observations and forecasts for Uintah Basin region.
+Live air-quality observations and forecasts for the Uintah Basin. Node/Express +
+Leaflet/Plotly, vanilla JS frontend.
 
-## Deployment Topology
-The operational core must be agnostic to which server / branch it runs on.
-
-| Role | Branch | Domain | pm2 app name |
+## Topology
+| Role | Branch | Domain | pm2 app |
 |---|---|---|---|
 | Production | `ops` | `www.basinwx.com` | `basinwx-ops` |
 | Rehearsal mirror | `dev` | `www.basinwx.dev` | `basinwx-dev` |
 
-- Both boxes: Linode, repo at `/srv/ubair-website`, pm2 run as the `deploy` user, nginx reverse proxy, Let's Encrypt certs.
-- pm2 app name is derived from `git rev-parse --abbrev-ref HEAD` (see `ecosystem.config.cjs`), so whichever branch is checked out dictates the running app identity.
-- `www.basinwx.dev` receives the same CHPC data as `.com` (fan-out upload) and runs whichever branch is checked out, so merging a PR into `dev` is a real-world dry-run before promotion to `ops`. It is also where stakeholder demos happen.
-- A third developer laptop/VM may also run this repo. It is **not operational**, may have broken paths, and must never be the source of truth.
-- Full bring-up runbook, nginx template, cert renewal, and "did this work?" sanity checklist live in `docs/DEPLOYMENT.md`.
-- **DNS is at Namecheap, not Linode.** Nameservers: `dns1/dns2.registrar-servers.com`. A wildcard A record (`*` → dev-box IP) covers every `<name>.basinwx.dev` subdomain, so new feature-branch previews need no DNS work — only nginx vhost + cert.
-- **Feature-branch previews** live at `<name>.basinwx.dev`, managed by `scripts/manage-previews.sh` + `preview-apps.json`. Runbook: `docs/DEPLOYMENT.md` §9. Background jobs (refresh, report emails) are gated on `PREVIEW_MODE=true` so previews don't double-burn upstream quotas.
+Both: Linode, repo at `/srv/ubair-website` as `deploy`, nginx + Let's Encrypt.
+The pm2 app name is derived from the checked-out branch (`ecosystem.config.cjs`),
+so the branch on disk dictates the running app identity. `.dev` receives the same
+CHPC fan-out as `.com` and is where stakeholder demos happen — merging into `dev` is
+a real-world dry-run before promoting to `ops`.
 
-### Bring-up lessons learnt (keep for future re-provisioning)
-- **Linode Cloud Firewall defaults to Drop.** A fresh linode blocks 80/443 until you explicitly accept them. Symptoms: `certbot renew --dry-run` times out on the ACME challenge, site is unreachable externally, but internal `curl -I http://127.0.0.1:${PORT}` works fine. Check each box's firewall rules in the Linode console before assuming nginx or certbot are broken.
-- **Don't use `certbot --manual` for these domains.** Its renewal config writes `authenticator = manual`, which the systemd timer cannot drive non-interactively — the cert silently fails to renew until it expires. Always use `certbot certonly --nginx` (or `--webroot`) so renewal is automated. Verify with `sudo certbot renew --dry-run`.
-- **`.dev` TLDs trip some client networks.** HSTS-preload plus occasional SNI-based filtering on corporate/campus/ISP routers produces "connection reset" errors that look like the server is down. Always phone-tether test (`curl -I https://www.basinwx.dev/` on a mobile hotspot) before blaming the server; if it works on cellular, the site is fine and the user's LAN is the culprit.
-- **`pm2 startup` is not optional.** Without the systemd unit a reboot silently loses the site. Confirm with `systemctl list-unit-files | grep pm2`.
+Feature-branch previews live at `<name>.basinwx.dev` (Namecheap wildcard A record),
+managed via `scripts/manage-previews.sh` + `preview-apps.json`. Background jobs are
+gated on `PREVIEW_MODE=true` so previews don't double-burn upstream quotas.
 
-## Data Pipeline
-**CHPC (compute server)** → **POST /api/upload/:dataType** → **both `www.basinwx.com` and `www.basinwx.dev`**
+A third dev laptop/VM may also run this repo: **not operational, never the source of truth.**
 
-### Data Flow
-1. **CHPC**: `brc-tools` fetches from Synoptic Weather API / HRRR via herbie-data
-2. **Processing**: polars/pandas → JSON
-3. **Transfer**: Secure POST to `/api/upload/:dataType` with API key + CHPC hostname validation, fanned out to every URL in `BASINWX_API_URLS` (first = primary, rest = best-effort mirrors)
-4. **Display**: Leaflet maps on Node.js website (live on `.com`, rehearsal on `.dev`)
+Bring-up runbook, nginx template, cert renewal, and chronic gotchas (Linode firewall
+default-Drop, certbot `--manual` trap, `.dev` TLD SNI filtering, pm2 systemd unit) are
+in `docs/DEPLOYMENT.md`. Read it before any provisioning work.
 
-### Data Types
-- **Live observations**: `map_obs_YYYYMMDD_HHMMZ.json` (geographic weather data)
-- **Station metadata**: `map_obs_meta_YYYYMMDD_HHMMZ.json` (station info)
-- **Time series**: Ozone concentration data
-- **Markdown outlooks**: Weather forecast text
-- **Images**: PNG files for visualization
-- **Forecasts**: Clyfar ensembles (`forecast_possibility_heatmap_*`, `forecast_exceedance_probabilities_*`, `forecast_percentile_scenarios_*`) and reduced HRRR surface layers (`forecast_hrrr_surface_layers_*`). Endpoint: `/api/upload/forecasts`. Full JSON schemas in `DATA_MANIFEST.json` §forecasts (~L247–L629). Server accepts any valid JSON; schema is not enforced server-side, so brc-tools is the contract-holder.
+## Data pipeline
+CHPC `brc-tools` (Synoptic + HRRR/herbie via polars/pandas) → POST `/api/upload/:dataType`
+with `x-api-key` + CHPC-hostname validation → fanned out to every URL in
+`BASINWX_API_URLS` (first = primary, rest = best-effort mirrors) → served at
+`/api/static/*` and `/api/filelist/:dataType`.
 
-## API Endpoints
-- **Upload**: `POST /api/upload/:dataType` (CHPC only, API key required)
-- **Fetch data**: `GET /api/static/{filename}`
-- **File listing**: `GET /api/filelist.json`
-- **Live observations**: `GET /api/live-observations`
+Accepted dataTypes (`server/routes/dataUpload.js`):
+`observations | metadata | outlooks | llm_outlooks | images | timeseries | forecasts | road-forecast`.
 
-## Security
-- API key authentication via `x-api-key` header
-- CHPC hostname validation (chpc.utah.edu)
-- File type validation (JSON/MD/TXT only)
-- 10MB file size limit
+Forecast schemas are pinned in `DATA_MANIFEST.json` (canonical contract; brc-tools is
+the contract-holder for new dataTypes — server doesn't enforce schema).
 
-## Tech Stack
-- **Backend**: Node.js, Express, Multer
-- **Frontend**: Leaflet, Plotly.js, vanilla JavaScript
-- **Data**: JSON files, Markdown content
+## Protected branches
+**Never push directly to `dev`, `ops`, or `main`.** All changes go through PRs. If a
+direct push seems warranted, confirm with the user — then ask a **second time** before
+proceeding. Applies to merges, reverts, version bumps, every commit.
 
-## Known Issues & Redundancy
-1. **Multiple CSS files** with similar styles (13 files)
-2. **Console.log statements** throughout codebase
-3. **TODO comments** for unfinished features
-4. **Unused code** in many files
-5. **Images folder** has many unused files
+## Secrets
+Loaded from `.env` (gitignored). Required: `DATA_UPLOAD_API_KEY`, `UDOT_API_KEY`,
+`SYNOPTIC_API_TOKEN`. Never commit, never echo values to logs or chat. Share via
+password manager.
+
+## Doc naming (LLM-produced markdown)
+- ALL-CAPS, **3–4 hyphen-separated words** (e.g. `DEPLOYMENT-RUNBOOK.md`,
+  `WEBSITE-BRCTOOLS-HANDOFF.md`). Avoid sentences-as-filenames.
+- Temporary/handoff docs: append `-mmmDD` before the extension (e.g.
+  `WEBSITE-BRCTOOLS-HANDOFF-apr27.md`) so future agents can spot expiry.
+- Markdown only. Python and other code files follow the language's convention
+  (lowercase, snake_case where applicable).
+
+## Reference docs (read on demand, not by default)
+- `docs/DEPLOYMENT.md` — bring-up runbook + chronic gotchas
+- `docs/IMPROVEMENTS.md` — outstanding work (flagged stale by JRL; renew before reuse)
+- `DATA_MANIFEST.json` — forecast schemas
+- `git log --oneline -30` — recent merges; do not duplicate here
 
 ## Testing
-- **Development**: `npm run dev` (nodemon)
-- **API testing**: `npm run test-api` (automated script)
-- **Manual API test**: `POST localhost:${PORT}/api/upload/observations` (PORT from `.env`; typically 3000 on ops, 3001 on dev)
-- **Example data**: Files in `/public/api/static/`
-
-## Features
-- **Responsive design**: Mobile/tablet friendly with percentage-based layouts
-- **90s Mode toggle**: Iridescent background with sparkle animations
-- **Secure uploads**: API key + hostname validation
-- **Real-time data**: Automatic refresh every 10 minutes
-
-## Recent Updates
-- **PR #182 (2026-04-24)**: per-user branch preview apps on subdomains — `preview-apps.json`, `scripts/manage-previews.sh`, `PREVIEW_MODE` gate in `server.js`, `docs/DEPLOYMENT.md` §9; also fixed `routes/trafficEvents.js` to use shared `TrafficEventsService` instance via injection (eliminating separate rate-limiter and cold-start double-poll against UDoT)
-- **PR #178 (2026-04-22)**: operational-agnosticism pass — branch-derived pm2 app name, fan-out CHPC uploader (`BASINWX_API_URLS`), `docs/DEPLOYMENT.md` runbook, host-aware sidebar brand
-- Implemented 90s mode toggle with holographic background
-- Created data schema documentation (DATA_SCHEMA.md)
-- Moved unused images to `/public/images/unused/`
-
-## Secret Management
-Environment variables are used for all API keys and sensitive configuration:
-- **Copy setup**: `cp .env.example .env` and fill in your values
-- **Required keys**: DATA_UPLOAD_API_KEY, UDOT_API_KEY, SYNOPTIC_API_TOKEN
-- **Never commit**: .env files are gitignored automatically
-- **Team sharing**: Use secure password manager (1Password, Bitwarden) for sharing secrets
-- **Production**: Set environment variables directly on server/cloud platform
-
-## Protected Branches
-**Never push directly to `dev`, `ops`, or `main`.**  All changes to these branches must go through a pull request. If you believe a direct push is warranted, ask the user to confirm — then ask a **second time** to be sure before proceeding. This applies to merges, reverts, version bumps, and any other commits.
-
-## Team Notes
-- Small collaborative team (lead + RAs — see README for current roster)
-- CSS-HTML mapping: fire.css ↔ fire.html pattern
-- 20-item improvement list available (IMPROVEMENTS.md)
+- `npm run dev` — nodemon server
+- `npm test` — Jest (currently has known failures in `cameraAnalysisScheduler.test.js`)
+- `npm run test-api` — loopback POST against the upload route

--- a/README.md
+++ b/README.md
@@ -1,248 +1,91 @@
 # Uintah Basin Air Quality Website
 
-## Overview
+Real-time weather and air-quality visualisation for the Uintah Basin, built for residents,
+researchers, and policymakers.
 
-Real-time weather data visualization and air quality monitoring platform for the Uintah Basin region of Utah, driven by needs of residents, researchers, and policymakers. The project is still developmental, is not yet purged of AI slop, and should be treated with caution. **The use of AI like Claude and Codex CLI agents is/must always be documented transparently** via `git` authorships etc. We are all still learning, and we ask you do not judge too harshly our codebase whilst in flux. The team lead John Lawson oversees all website updates and [welcomes feedback](mailto:john.lawson@usu.edu). All products on BasinWx are currently experimental: do not use them for critical decision-making.
+> **Live site:** [basinwx.com](https://basinwx.com) (mirror: [basinwx.dev](https://www.basinwx.dev))
+>
+> The project is still developmental and not yet purged of AI slop — treat with caution. All
+> products are experimental; do not use them for critical decisions. Feedback to
+> [john.lawson@usu.edu](mailto:john.lawson@usu.edu).
 
-**Live Site:** [basinwx.com](https://basinwx.com)
-
-## Features (_gradual introduction in November 2025_)
-
-- **Real-time Observations**: live weather and air-quality data year-round
-- **Ozone Alert outlooks**: human-written forecasts of wintertime ozone.
-- **Clyfar**: Our in-house model, Welsh for "wise", provides guidance for outlooks
-- **AQ and Wx Forecasts**: Weather-model forecasts and air-quality predictions
-- **Road Conditions**: using UDot data
-- **AI-generated overviews**: we are testing plain-language risk communication
-- **Mobile Responsive**: Optimized for devices large and small.
+## What's here
+- **Real-time observations** — live weather + air-quality, year-round
+- **Ozone Alert outlooks** — human-written wintertime ozone forecasts
+- **Clyfar** — in-house ensemble model (Welsh "wise") providing outlook guidance
+- **Forecasts** — weather-model outputs and air-quality predictions
+- **Road conditions** — UDoT data, advisory only (go to [udottraffic.utah.gov](https://udottraffic.utah.gov) for real decisions)
+- **AI overviews** — experimental plain-language risk communication
+- **Mobile responsive**
 
 ## Human-to-human warnings
-- This codebase moves fast, and repo bloat is a problem. Ideally,
-  - We encourage low verbosity
-  - We prune outdated content and combine overlapping files
-  - We embrace transparent, ethical use of AI during development
-  - This means always co-authoring `git commit`s to own your code!
+This codebase moves fast. Repo bloat is a known problem.
+- Low verbosity preferred; prune outdated content; merge overlapping files
+- AI-assisted development is welcome and **must** be transparent — co-author every `git commit`
 
-## Technical Architecture
+## Architecture (one paragraph)
+CHPC compute (`brc-tools`, Python) fetches Synoptic + HRRR data, processes via polars/pandas,
+POSTs JSON to `/api/upload/:dataType` on **two Linode boxes** (`www.basinwx.com` ops and
+`www.basinwx.dev` rehearsal mirror — fan-out from CHPC, not pull). The Node/Express + Leaflet/Plotly
+frontend reads from `/api/static/*`. DNS for `.dev` is at Namecheap with a wildcard A record so
+feature-branch previews need no DNS work — `scripts/manage-previews.sh` spins them up at
+`<name>.basinwx.dev`. Forecast schemas are pinned in `DATA_MANIFEST.json`.
 
-```
-CHPC (Data Processing) → API Upload (fan-out) → Linode (.com ops + .dev rehearsal) → Web Interface
-```
+## Documentation
+| Audience | Start here |
+|---|---|
+| **AI agents** | `CLAUDE.md` (root, auto-loaded) → `docs/AGENT-INDEX.md` |
+| **Human devs** | `docs/README.md` → `docs/QUICK-START.md` |
+| **Operators** | `docs/DEPLOYMENT.md` (bring-up, certs, firewall, gotchas) |
+| **Data pipeline** | `docs/DATA-PIPELINE-OVERVIEW.md` + `DATA_MANIFEST.json` |
+| **Per-feature SOPs** | `docs/SOP-*.md`, `docs/howto/*.md` |
 
-- **Backend**: Node.js, Express.js, pm2
-- **Frontend**: Vanilla JavaScript, Leaflet, Plotly.js
-- **Data Pipeline**: Python (brc-tools), Synoptic Weather API; forecast products (Clyfar ensembles, reduced HRRR surface layers) POST to `/api/upload/forecasts` — schema in `DATA_MANIFEST.json`
-- **Deployment**: Two Linode boxes (`www.basinwx.com` ops, `www.basinwx.dev` rehearsal mirror), nginx reverse proxy, Let's Encrypt TLS. DNS for `basinwx.dev` is at **Namecheap** with a wildcard A record (`*` → dev-box IP)
-- **Feature-branch previews**: any in-progress branch can be spun up at `<name>.basinwx.dev` via a git worktree + pm2 pair managed by `scripts/manage-previews.sh`. New previews need no DNS work thanks to the wildcard. See `docs/DEPLOYMENT.md` §9
+A current docs triage with consolidation TODOs is in `REVIEW-DOCS-apr27.md` (root).
 
-## Documentation --- still in flux and requiring review for AI slop
-
-- [API Key Setup](docs/API-KEY-SETUP.md)
-- [Data Schema](docs/DATA-SCHEMA.md)
-- [Frontend Architecture](docs/FRONTEND-ARCHITECTURE.md)
-- [Python Developer Guide](docs/PYTHON-DEVELOPER-GUIDE.md)
-- [Winter Ozone Science](docs/WINTER-OZONE-SCIENCE.md)
-
-## Research & Publications
-
-### Scientific Papers
-- *Techical report*: Clyfar (air-quality forecasting) design for 2025/2026
-- *In Preparation*: _Preprint articles for extreme nerds, and plain-language pieces for easier reading!_
-- *Publication goals in 2026**: Clyfar evaluation and comprehensive description
-
-### Blog Posts & long-form articles
-- TBC: straightforward summaries of our research
-- TBC: team activities, especially those of our students
-- TBC: showcase of posts re: complex elements of Ozone Alert outlooks not discussed in emails
-
-## Roadmap & To-Dos
-
-### Near-term (2025)
-- [ ] Forecast evaluation
-- [ ] LLM-powered data interpretation
-- [ ] Stability testing as `beta` becomes `ops`.
-- [ ] Consistently pleasing mobile interface
-
-### Mid-term (2026)
-- [ ] Review of feedback
-- [ ] Improvements to forecast models
-- [ ] Further road-weather, aviation, and recreation focus
-
-### Next year's winter (2026/2027)
-- [ ] Interactive Q&A chatbot for weather queries
-- [ ] Experimental data and models
-- [ ] Educational, interactive data visualizations
-- [ ] Regional expansion where warranted (e.g. Wyoming; Wasatch Front)
 ## Contributing
+Three audiences: human devs (architecture, setup, workflow), end users (plain-language guides),
+and AI agents (`CLAUDE.md`, schemas, system context). Keep docs terse, current, and
+audience-appropriate. PRs welcome. Use GitHub Issues for bugs.
 
-We welcome contributions. Guidelines:
+- **Style:** low verbosity; prune bloat
+- **Tests:** TDD where practical (`npm test`)
+- **AI authorship:** every commit involving AI assistance must list the agent as a co-author
+- **Branches:** never push directly to `dev`/`ops`/`main` — see `CLAUDE.md`
 
-- **Code style standards**: Low verbosity, prune bloat, transparent AI use
-- **Testing requirements**: Test-driven workflow to catch regressions early (see #91)
-- **Pull-request process**: Co-author git commits, review before merge
-- **Bug reporting**: Use GitHub Issues with clear reproduction steps
-- **Working with AI agents**: Document all AI contributions via git authorship
-
-### Documentation Philosophy
-We maintain docs for three audiences:
-1. **Human developers** - Technical architecture, setup guides, contribution workflow
-2. **Typical users** - Plain-language explainers, feature guides, contact info  
-3. **AI agents** - Context files (CLAUDE.md), data schemas, system architecture
-
-Keep docs terse, current, and audience-appropriate. Prune outdated content aggressively.
-
-## Cool Commands (CHPC / Ops)
-
-A collection of useful commands for monitoring and debugging. **PRs welcome** to add your own!
-
-### Job Monitoring
+## Quick health checks
 ```bash
-# Watch all recent SLURM jobs (live updating)
-watch -n 5 "sacct --starttime=now-24hours --format=JobID,JobName,State,Start,Elapsed | sort -k4 -r"
-
-# Tail the newest Clyfar log automatically
-tail -f $(ls -t ~/logs/basinwx/clyfar_*.out | head -1)
-
-# Check resource usage after job completes
-sacct -j JOBID --format=JobID,JobName,MaxRSS,MaxVMSize,CPUTime,Elapsed,State,ExitCode
-```
-
-### Quick Health Checks
-```bash
-# Are observations flowing?
 curl -s https://basinwx.com/api/live-observations | jq '.totalObservations'
-
-# How many forecast files?
 curl -s https://basinwx.com/api/filelist/forecasts | jq 'length'
-
-# Server logs (ops box)
 ssh deploy@www.basinwx.com "pm2 logs --lines 50"
-
-# Server logs (dev / rehearsal box)
 ssh deploy@www.basinwx.dev "pm2 logs --lines 50"
 ```
 
-### Automated Email Report
-The server can send a scheduled monitoring report email (pipeline status + camera scheduler stats).
+If the site appears down: check from a phone hotspot first. `.dev` TLDs trip some campus/ISP
+networks (HSTS-preload + SNI filtering); cellular working but wifi not = not the server. Full
+triage in `docs/DEPLOYMENT.md`.
 
-Set these environment variables on the server:
-```bash
-REPORT_EMAIL_ENABLED=true
-REPORT_EMAIL_TO=you@example.com
-REPORT_EMAIL_FROM=basinwx@example.com
-REPORT_EMAIL_SMTP_HOST=smtp.example.com
-REPORT_EMAIL_SMTP_PORT=587
-REPORT_EMAIL_SMTP_SECURE=false
-REPORT_EMAIL_SMTP_USER=your-smtp-user
-REPORT_EMAIL_SMTP_PASS=your-smtp-password
-REPORT_EMAIL_SCHEDULE_ENABLED=false
-REPORT_EMAIL_CRON="0 8 * * *"
-REPORT_EMAIL_TIMEZONE=America/Denver
-REPORT_EMAIL_NOTIFY_ON_STARTUP=true
-REPORT_EMAIL_NOTIFY_ON_SHUTDOWN=true
-REPORT_EMAIL_SUBJECT_PREFIX="BasinWx Status Report"
-```
-
-Notes:
-- `REPORT_EMAIL_CRON` uses standard 5-field cron format.
-- Lifecycle reports are controlled by `REPORT_EMAIL_NOTIFY_ON_STARTUP` and `REPORT_EMAIL_NOTIFY_ON_SHUTDOWN`.
-- Scheduled reports are optional and require `REPORT_EMAIL_SCHEDULE_ENABLED=true`.
-- Service is disabled unless `REPORT_EMAIL_ENABLED=true`.
-
-Warm-restore metric endpoint:
-```bash
-curl -s https://basinwx.com/api/road-weather/camera-scheduler-status | jq '.warmRestore'
-```
-Returns startup restore diagnostics including:
-- `restoredDetectionsCount`
-- `restoredSnapshotAgeMinutes`
-
-### Storage Triage
-```bash
-# Find GEFS cache hogs
-find ~ -name "*.grib2" -type f 2>/dev/null | head -20
-
-# Quick quota check
-df -h ~
-```
-
-See `STORAGE-TRIAGE-URGENT.md` for full storage management guide.
-
-### Git Hooks
-
-Git hooks are scripts that run automatically on certain git events. Useful for reminders and automation.
-
-**Post-merge hook** (reminds to npm install after pull):
-```bash
-cat > .git/hooks/post-merge << 'EOF'
-#!/bin/bash
-if git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep -q "package.json"; then
-    echo "⚠️  package.json changed - run: npm install"
-fi
-EOF
-chmod +x .git/hooks/post-merge
-```
-
-### "Is the site actually down?" — triage in order
-Before escalating, rule out the easy causes. The server has been guilty only ~half the time during bring-up.
-
-```bash
-# From your laptop
-curl -I https://www.basinwx.dev/          # expect HTTP/2 200
-curl -I https://www.basinwx.com/          # expect HTTP/2 200
-```
-
-If either RSTs or times out, tether your laptop to your phone's hotspot and retry the same curl. Cellular working but wifi not = your current network (campus/office/ISP) is SNI-filtering `.dev` (HSTS-preloaded, new-TLD-suspicious) or has a stale resolver cache. The server is fine; clear your browser's HSTS+DNS cache or work from a different network.
-
-If cellular also fails, it's the server. SSH in and walk the "did this work?" checklist in `docs/DEPLOYMENT.md` §6 (branch, pm2, systemd unit, `.env` perms, internal curl, nginx config, 80/443 listening, cert expiry, external curl, pm2 logs). Known landmines picked up during first-time bring-up: **Linode Cloud Firewall defaults to Drop** (80/443 must be explicitly accepted per box); **`certbot --manual` breaks auto-renewal** — use `--nginx` or `--webroot`.
-
-### Data Troubleshooting
-```bash
-# Clyfar's Herbie cache (not default ~/.cache/herbie)
-CACHE=~/gits/clyfar/data/herbie_cache
-
-# After crash: find/delete corrupted downloads (zero or tiny files)
-find $CACHE -size 0 -name "*.grib2" -delete
-find $CACHE -size -1k -name "*.grib2" -delete
-
-# Nuclear option: clear today's cache and re-run
-rm -rf $CACHE/gefs/$(date +%Y%m%d)/
-```
-
----
-
-## Data Sources
-
-- **Synoptic Data**: Real-time meteorological observations compiling multiple sources (e.g., EPA, DAQ, Union Pacific, etc)
-- **UBAIR Sensors**: Research-grade monitoring equipment maintained by Trevor O'Neil and Seth Lyman here at the Bingham Research Center
-- **NOAA weather models**: The Federal data are [freely available](https://www.nco.ncep.noaa.gov/pmb/products/gens/) and _crucial_ drivers of most weather and air-quality information shown on BasinWx.
-- **Utah Department of Transportion**: Road conditions are provided under fair-use limits for advisory use only: for critical decision, go to [UDoT](https://udottraffic.utah.gov) for vetted, expanded information.
-- (TBC: Ouray vertically-pointing radar)
-- (TBC: Satellite imagery)
+## Data sources
+- **Synoptic** — real-time meteorological observations (EPA, DAQ, Union Pacific, etc.)
+- **UBAIR sensors** — research-grade monitoring maintained by Trevor O'Neil and Seth Lyman at the Bingham Research Center
+- **NOAA models** — federal data freely available at the [NCEP product portal](https://www.nco.ncep.noaa.gov/pmb/products/gens/)
+- **UDoT** — road conditions under fair-use limits (advisory only)
 
 ## Team
-
-Find more information at [our team site](https://jrl.ac/team), but our primary developers are:
+[Team page](https://jrl.ac/team). Primary developers:
 - Dr. John R. Lawson (lead)
 - Michael Davies (undergraduate RA)
+- Quinten Baldwin, Braxton Wilcken-Pond (sports & viz contributors)
+- Luke Neilson (high-school RA, onboarding)
 - Elspeth Montague (former high-school RA)
-- Luke Neilson (currently onboarding; high-school RA)
-- TBC 1 - high-school RA
-- TBC 2 - high-school RA
-- TBC 3 - high-school RA
 
 ## Acknowledgments
-
-- Research funding for air-quality projects provided by **Uintah County Special Service District 1** and the **Utah Legislature**
-- University of Utah CHPC for computational resources
-- Synoptic Weather for kindly permitting access to archived and live data
-- Brian Blaylock, Alex Jacques, John Horel, and many more academics who assisted with development
-- You! The user and Uintah Basin community! Thanks for coming!
+- Funding: **Uintah County Special Service District 1** and the **Utah Legislature**
+- University of Utah CHPC (compute)
+- Synoptic Weather (data access)
+- Brian Blaylock, Alex Jacques, John Horel, and many other academic collaborators
 
 ## Contact
-
-Other than JRL's [email address](mailto:john.lawson@usu.edu), further information or feedback can be found here:
-- Team "Spotlight" posts [for plain-language team blog posts](https://jrl.ac/blog).
-- Ozone Alert program for receiving email outlooks when there is a elevated risk of **high wintertime ozone** in the Uinta Basin.
-- GitHub Issues: [Report bugs or request features (more for the tech-minded)](https://github.com/bingham-research-center/ubair-website/issues)
----
+- [john.lawson@usu.edu](mailto:john.lawson@usu.edu) — JRL direct
+- [Team blog](https://jrl.ac/blog) — plain-language posts
+- [GitHub Issues](https://github.com/Bingham-Research-Center/ubair-website/issues) — bugs and feature requests
+- Ozone Alert subscription — email outlooks during elevated risk periods

--- a/REVIEW-DOCS-apr27.md
+++ b/REVIEW-DOCS-apr27.md
@@ -1,0 +1,126 @@
+# REVIEW-DOCS-apr27.md
+# Status: TEMPORARY (snapshot for consolidation work; delete or supersede after the listed TODOs land)
+# Compiled: 2026-04-27 by Claude Opus 4.7 in the ubair-website dev branch
+# Audience: AI agents + human devs working on docs hygiene
+
+## TL;DR
+- `docs/` contains 50 markdown files (~13.2k lines, 24 files >250 lines).
+- Several confirmed duplicate / overlapping pairs and triplets — list below.
+- `docs/AGENT-INDEX.md` was 5 months stale; refreshed in this PR but the underlying docs it points to still need consolidation.
+- Five overlapping TODO/improvement docs (`IMPROVEMENTS.md`, `TODO-DEFERRED.md`, `WISHLIST-TODOS.md`, `DEPLOYMENT-SPECS-TODO.md`, `PYTHON-DEVELOPER-TODO.md`) — single-source these.
+- README.md trimmed in this PR (248 → ~110 lines).
+- This document is a **snapshot, not authority**. Verify each item before acting.
+
+---
+
+## Audience question (decided 2026-04-27 with JRL)
+The same `docs/` folder serves both AI agents and human devs. We agree this is fine *if*:
+1. There is a single canonical index per audience: `docs/AGENT-INDEX.md` (agents) and `docs/README.md` (humans, currently a stub — TODO to expand).
+2. Each file states its audience in the first 2 lines (date + audience tag).
+3. SOPs (`SOP-*.md`) are authoritative for both — they describe the procedure regardless of who runs it.
+
+If the workflow ever splits (e.g. SOPs migrate to GitHub Wiki per `docs/README.md`'s TODO), revisit.
+
+---
+
+## Categorisation (for navigation, not consolidation)
+
+### Architecture & data pipeline
+- `DATA-PIPELINE-OVERVIEW.md` (438 lines) — keep, primary
+- `DATA-SCHEMA.md` — keep
+- `HOW_IT_WORKS.md` (524 lines) — overlaps `FRONTEND-ARCHITECTURE.md`; **TODO** check overlap
+- `FRONTEND-ARCHITECTURE.md` (415) — keep, primary
+- `JAVASCRIPT-PATTERNS.md` (414) — keep
+- `MANIFEST-GUIDE.md` (360) + `MANIFEST-CHANGELOG.md` — keep both (guide + append-only log)
+- `PIPELINE-STATUS.md` + `PIPELINE-SUMMARY.md` + `README-PIPELINE.md` — **TODO** triplet to consolidate; pick one
+- `python-side-CLAUDE.md` — meant to be **copied to the brc-tools repo**, not used in-place. **TODO** rename or relocate to clarify (e.g. `templates/BRCTOOLS-CLAUDE-TEMPLATE.md`)
+
+### Deployment & ops
+- `DEPLOYMENT.md` (256) — keep, primary
+- `CHPC-DEPLOYMENT.md` (531) + `CHPC-IMPLEMENTATION.md` (722) — **TODO** confirmed overlap; merge
+- `SSL-SETUP.md` — keep
+- `DEPLOYMENT-SPECS-TODO.md` — **TODO** absorb into `IMPROVEMENTS.md` or close out
+- `STORAGE-TRIAGE-URGENT.md` — referenced from README but not present at top-level; **TODO** locate (likely in `archive/`) and remove dangling reference
+
+### Branching, PRs, workflow
+- `BRANCHING-WORKFLOW.md` (282) — keep, primary
+- `BRANCHING-STRATEGY-IMPLEMENTATION.md` (699) — **TODO** confirmed overlap; merge or archive
+- `PR-REVIEW-PROMPT-TEMPLATE.md` — keep
+
+### Cron & scheduling
+- `CRONJOB-ADVICE.md` (481) — keep, primary
+- `CRON_SCHEDULE_ANALYSIS.md` — **TODO** check overlap with `CRONJOB-ADVICE.md`
+- `CRON-SETUP-27NOV2025.md` — date-stamped from Nov 2025; **TODO** move to `archive/`
+- `API_RATE_CALCULATIONS.md` + `API_RATE_CALCULATIONS_HYBRID.md` — pair; one is "current" + one is "proposed". **TODO** decide which is now reality, archive the other
+
+### Camera / road weather
+- `CAMERA_ANALYSIS_SCHEDULER.md` (240) — keep
+- `CAMERA_CLUSTERING_IMPLEMENTATION.md` (778) — keep but **TODO** check whether superseded by post-#177 modular code
+- `CONFIDENCE_TAXONOMY.md` (257) — keep
+- `ROADS_AUDIT.md` — keep
+- `ROAD_WEATHER_IMPROVEMENTS.md` (578) — **TODO** scan for done items; consolidate remaining into `IMPROVEMENTS.md`
+
+### API & secrets
+- `API-KEY-SETUP.md` — keep, primary
+- `API_FIX_SUMMARY.md` (331) — looks like a transient session artefact; **TODO** move to `archive/` or extract permanent learnings into `API-KEY-SETUP.md`
+- `SECRET-SHARING-GUIDE.md` — keep
+
+### Python side (brc-tools cross-repo)
+- `python-developer-guide.md` (382) — keep, primary
+- `PYTHON-PACKAGING-DEPLOYMENT.md` (774) — keep
+- `PYTHON-DEVELOPER-TODO.md` — **TODO** merge into `IMPROVEMENTS.md` or relocate to brc-tools repo
+
+### SOPs & howtos
+- `SOP-outlook-upload.md` — keep, primary
+- `howto/preview-a-branch.md` — keep
+- `howto/avoiding-dev-domain-block.md` — keep
+- `howto/quinten-handoff.md` — RA-onboarding pattern; consider promoting to `ONBOARDING.md` if it generalises
+
+### Reference / context
+- `WINTER-OZONE-SCIENCE.md` (274) — keep
+- `EASTER-EGGS.md` (453) — keep
+- `synoptic_api_var_docs.pdf` — keep (binary, fine)
+- `TEST-DATA.md` + `TESTING-PLAN.md` — keep both
+
+### Outstanding-work indices (the pile)
+- `IMPROVEMENTS.md` — refreshed 2026-04-27 in this PR (was flagged "half done")
+- `TODO-DEFERRED.md` — Clyfar Nov-2025 carry-over; partly stale
+- `WISHLIST-TODOS.md` — long-tail
+- `DEPLOYMENT-SPECS-TODO.md` — deployment-specific
+- `PYTHON-DEVELOPER-TODO.md` — brc-tools-specific
+- `ROAD_WEATHER_IMPROVEMENTS.md` — feature-area-specific
+- **TODO** — collapse to one of: (a) `IMPROVEMENTS.md` as single source with sections per feature, or (b) GitHub Issues with labels. Five overlapping lists is the worst possible state.
+
+### Quick reference
+- `AGENT-INDEX.md` — refreshed in this PR
+- `QUICK-START.md` (257) — **TODO** verify currency; may have drifted with the recent merges
+- `README.md` (in `docs/`) — currently a 17-line stub; **TODO** expand into the human-side counterpart of `AGENT-INDEX.md`
+
+### Archive
+- `archive/` — 10 files of historical session handoffs and superseded plans. Do not read unless tracing history.
+
+---
+
+## Naming-convention violations (cosmetic; rename in a follow-up PR)
+Per the `CLAUDE.md` rule (ALL-CAPS, hyphens, 3–4 words for LLM-produced markdown):
+- Underscores instead of hyphens: `HOW_IT_WORKS.md`, `API_FIX_SUMMARY.md`, `API_RATE_CALCULATIONS*.md`, `CAMERA_ANALYSIS_SCHEDULER.md`, `CAMERA_CLUSTERING_IMPLEMENTATION.md`, `CONFIDENCE_TAXONOMY.md`, `CRON_SCHEDULE_ANALYSIS.md`, `ROAD_WEATHER_IMPROVEMENTS.md`
+- Mixed case: `python-developer-guide.md`, `python-side-CLAUDE.md` (these may be grandfathered; check author intent)
+- Date suffix wrong format: `CRON-SETUP-27NOV2025.md` should be archived or renamed to `CRON-SETUP-nov27.md` per the new convention
+
+A bulk rename would land cleanly as a single chore PR; defer until the consolidation TODOs above are resolved so we don't rename twice.
+
+---
+
+## Recommended order of operations
+1. **Now (this PR):** rename + push `WEBSITE-BRCTOOLS-HANDOFF-apr27.md`, trim `CLAUDE.md`, refresh `AGENT-INDEX.md`, refresh `IMPROVEMENTS.md`, write this review.
+2. **Next chore PR:** merge the BRANCHING pair, merge the CHPC pair, decide on the API_RATE pair, expand `docs/README.md`.
+3. **Following chore PR:** collapse the five TODO docs into one (or one + GH Issues).
+4. **Cosmetic PR:** bulk-rename underscored filenames; relocate `python-side-CLAUDE.md`.
+5. **Archive sweep:** move `CRON-SETUP-27NOV2025.md`, `API_FIX_SUMMARY.md` (if transient), and any other date-stamped session artefact into `archive/`.
+
+Each of 2–5 is small enough for a single agent session. None should affect the running website.
+
+---
+
+## Done
+- 2026-04-27 — review compiled, AGENT-INDEX refreshed, README trimmed (248→~110), IMPROVEMENTS refreshed.

--- a/WEBSITE-BRCTOOLS-HANDOFF-apr27.md
+++ b/WEBSITE-BRCTOOLS-HANDOFF-apr27.md
@@ -1,0 +1,359 @@
+# BASINWX-DEV → BRC-TOOLS HANDOFF
+# From: Bingham-Research-Center/ubair-website (branch `dev`, HEAD a14fd93)
+# To: brc-tools repo on CHPC (whichever path your session is in)
+# Compiled: 2026-04-27
+# Format: AI-agent consumption — code-first, dense, minimal prose
+# Audience: Claude session running in brc-tools/ on CHPC. The human will copy this file in.
+
+---
+
+## YOUR JOB IN ONE SENTENCE
+
+Three new website features merged into `dev` (PRs #176, #183, #188) consume dataTypes
+that brc-tools has never produced or uploaded. Fix that, AND repair the fan-out so
+`.dev` receives the same forecasts as `.com`. Do not change the website-side endpoint
+contract — match the schemas below and the website will light up automatically.
+
+---
+
+## TOPOLOGY (refresher — do not re-derive)
+
+| Box | Domain | Branch | pm2 app | Purpose |
+|---|---|---|---|---|
+| linode-prod | www.basinwx.com | `ops` | `basinwx-ops` | production |
+| linode-dev | www.basinwx.dev | `dev` | `basinwx-dev` | rehearsal mirror, stakeholder demos |
+
+Both boxes accept identical CHPC uploads via `POST /api/upload/:dataType`. The only thing that
+differs is which branch of code is checked out. brc-tools is the **single source of truth** for
+forecast/observation data; both website boxes are downstream consumers. Fan-out is brc-tools'
+responsibility — receivers don't pull, they receive POSTs.
+
+---
+
+## CONFIRMED BROKEN (verified by curl 2026-04-27)
+
+```
+✓ observations/                   5-min cadence on .com AND .dev (control: fan-out works for this dataType)
+✓ outlooks/                       present on both
+✗ forecasts/forecast_clustering_*  100s of files on .com, ZERO on .dev      ← fan-out gap
+✗ forecasts/forecast_hrrr_kvel_*   ZERO on .com, ZERO on .dev               ← never produced (PR #183 dark)
+✗ forecasts/forecast_hrrr_surface_layers_*  ZERO on both                    ← never produced (PR #176 dark since 2026-04-17)
+✗ road-forecast/latest.json       404 on both                               ← never produced (PR #188 dark)
+```
+
+**The fan-out gap is the canary.** It proves brc-tools has at least two upload paths:
+one that respects multi-target fan-out (observations) and one that doesn't (clustering forecasts).
+Find the second path, make it match the first.
+
+---
+
+## UPLOAD ENDPOINT — exact contract
+
+```
+POST  https://www.basinwx.com/api/upload/:dataType
+POST  https://www.basinwx.dev/api/upload/:dataType
+```
+
+**Auth (both required):**
+- Header `x-api-key: $DATA_UPLOAD_API_KEY` (same secret on both boxes; brc-tools .env should have it)
+- Either:
+  - Header `x-client-hostname: <something>.chpc.utah.edu`, OR
+  - Reverse-DNS of source IP resolves to `*.chpc.utah.edu`
+
+The hostname header is fastest and avoids DNS lookups. Set it once in your HTTP client.
+
+**Multipart body (multer):**
+- Field name: `file` (literal — `upload.single('file')` in `server/routes/dataUpload.js:141`)
+- Filename: preserved as uploaded — match the `filename.pattern` in DATA_MANIFEST.json
+- Size limit: 10 MB per upload
+- Allowed extensions: JSON, MD, TXT (binary forecast files won't pass — gzip+base64 inside JSON if you must)
+
+**Accepted dataTypes** (see `server/routes/dataUpload.js:30-40`):
+```
+observations | metadata | outlooks | llm_outlooks | images | timeseries | forecasts | road-forecast
+```
+
+Anything else gets a 400. Don't invent new dataTypes without a website-side PR first.
+
+**Response shape:**
+```json
+{ "success": true, "filename": "...", "dataType": "..." }
+```
+HTTP 200 = stored. 401 = bad/missing API key. 403 = not from CHPC. 413 = >10 MB.
+
+**Reference Python snippet (verified contract):**
+```python
+import requests
+with open(local_path, 'rb') as f:
+    r = requests.post(
+        f"{base_url}/api/upload/{data_type}",
+        headers={
+            "x-api-key": os.environ["DATA_UPLOAD_API_KEY"],
+            "x-client-hostname": socket.gethostname(),  # must end .chpc.utah.edu
+        },
+        files={"file": (os.path.basename(local_path), f, "application/json")},
+        timeout=30,
+    )
+    r.raise_for_status()
+```
+
+---
+
+## FAN-OUT CONFIG — `BASINWX_API_URLS`
+
+The website's CLAUDE.md and PR #178 say uploads are fanned out to a comma-separated list of
+URLs read from `BASINWX_API_URLS` (first = primary, rest = best-effort mirrors). For the
+forecasts gap, **find the uploader that doesn't read this var and fix it.**
+
+Suggested target value on CHPC:
+```bash
+export BASINWX_API_URLS="https://www.basinwx.com,https://www.basinwx.dev"
+```
+
+Audit pattern (run inside brc-tools/):
+```bash
+# How many distinct upload helpers exist?
+grep -rn "BASINWX_API_URLS\|basinwx.com\|basinwx.dev" --include='*.py' --include='*.sh'
+
+# Each producer (clyfar, hrrr, observations, ...) likely has its own upload call.
+# The ones hardcoding www.basinwx.com or single-URL env vars are the ones not fanning out.
+```
+
+Fix once, centrally — share one `upload()` helper across all producers. Don't paper over per-call.
+
+---
+
+## DATATYPE 1 — `road-forecast` (PR #188)
+
+**Endpoint:** `POST /api/upload/road-forecast`
+**Filename:** `road_forecast_<YYYYMMDD_HHMMZ>.json` (any pattern; server preserves it)
+**Server side-effect:** automatically copies the upload to `public/api/static/road-forecast/latest.json`
+(see `server/routes/dataUpload.js:189`). brc-tools doesn't need a "latest" alias.
+**Cadence:** every HRRR run is fine (hourly), but every 3h matches website caching (`server/roadWeatherService.js:368-396` caches for 1h, rejects if `init_time` >3h old).
+**Manifest entry:** does not yet exist — Tier 1.2 on the website side will add one. Coordinate.
+
+**Schema (extracted from `server/roadWeatherService.js:loadHRRRForecast` + `getHRRRConditionAtPoint`):**
+```jsonc
+{
+  "init_time": "2026-04-27T18:00:00Z",     // ISO-8601 UTC. REJECTED if >3h old at read time.
+  "model": "hrrr",                          // optional, recommended
+  "domain": "uintah_basin_roads",           // optional, recommended
+  "points": [
+    {
+      "lat": 40.4555,
+      "lon": -110.0532,
+      "name": "US-40 MP 90 (optional)",
+      "forecasts": [
+        {
+          "valid_time": "2026-04-27T19:00:00Z",  // optional but recommended
+          "temp_2m": -2.3,            // °C    ← NOT Kelvin. The "523°F" disaster of #170 is why.
+          "precip_1hr": 0.5,           // mm
+          "precip_type": "snow",       // "snow" | "rain" | "mixed" | "none"
+          "wind_speed_10m": 4.2,       // m/s (the website assumes m/s; document any deviation)
+          "visibility": 12.5           // km — website multiplies ×1000 to get metres
+        }
+        // ...as many forecast hours as you want; website uses [0] for "now"
+      ]
+    }
+    // Aim for grid coverage of UTH-1, UTH-2, US-40, US-191. ~50-200 points is fine.
+  ]
+}
+```
+
+**Verification curl (after upload + fan-out fix):**
+```bash
+curl -fsS https://www.basinwx.dev/api/static/road-forecast/latest.json | jq .init_time
+curl -fsS https://www.basinwx.com/api/static/road-forecast/latest.json | jq .init_time
+# Should be the same ISO timestamp, <3h old.
+curl -fsS https://www.basinwx.dev/api/road-weather/forecast | jq .success
+# Should be `true`. (Currently returns "No HRRR road forecast available".)
+```
+
+---
+
+## DATATYPE 2 — `forecast_hrrr_kvel_crosswind_*` (PR #183)
+
+**Endpoint:** `POST /api/upload/forecasts`  (note: shared with Clyfar/clustering — same dataType, different filename prefix)
+**Filename pattern:** `forecast_hrrr_kvel_crosswind_<YYYYMMDD_HHMMZ>.json`
+**Cadence:** every HRRR cycle (hourly OK; suggest at least 4×/day matching the existing forecasts schedule)
+**Manifest entry:** does not yet exist — coordinate with website side.
+
+**Schema (extracted from `public/js/aviation.js:14-50`):**
+```jsonc
+{
+  "product": "aviation_crosswind",         // literal — consumer checks this string
+  "model": "hrrr",                          // becomes the page header
+  "init_time": "2026-04-27T18:00:00Z",
+  "valid_times": [                          // time labels for table columns
+    "2026-04-27T19:00Z", "2026-04-27T20:00Z", "..."
+  ],
+  "series": {
+    "crosswind_kt_rwy16": [3.2, 4.1, ...],  // knots; positive = crosswind from one side
+    "crosswind_kt_rwy34": [-3.2, -4.1, ...] // negative = from the other (paired with rwy16)
+    // Add headwind/tailwind series if the page evolves; current consumer only renders crosswind_kt_*.
+  },
+  "metadata": {                             // optional
+    "station": "KVEL",
+    "lat": 40.4408,
+    "lon": -109.5119,
+    "runway_headings_deg_true": [160, 340]
+  }
+}
+```
+
+KVEL has runways 16/34 (and was historically 7/25 — verify current chart). The series tags
+(`crosswind_kt_<runway>`) must match what the consumer iterates: see line 42 of `aviation.js`.
+
+**Verification:**
+```bash
+curl -fsS https://www.basinwx.dev/api/filelist/forecasts | python3 -c '
+import sys,json
+files = json.load(sys.stdin)
+kvel = sorted([f for f in files if f.startswith("forecast_hrrr_kvel_crosswind_")])
+print("count:", len(kvel), "newest:", kvel[-1] if kvel else None)
+'
+# Then visually: open https://www.basinwx.dev/aviation — the crosswind table should populate.
+```
+
+---
+
+## DATATYPE 3 — `forecast_hrrr_surface_layers_*` (PR #176, dark since 2026-04-17)
+
+**Endpoint:** `POST /api/upload/forecasts`
+**Filename pattern:** `forecast_hrrr_surface_layers_<YYYYMMDD_HHMMZ>.json`
+**Cadence:** existing forecasts schedule (cron `30 3,9,15,21 * * *` UTC, 3.5h after GEFS runs)
+**Manifest entry:** **already exists** at `DATA_MANIFEST.json:487` — read it as the canonical schema source. Do not invent fields.
+
+```bash
+# In ubair-website:
+sed -n '487,610p' DATA_MANIFEST.json   # full schema for hrrr_surface_layers
+```
+
+The schema's `product_type` enum is `"surface_layers"` (line 519). Honour it.
+
+**Verification:**
+```bash
+curl -fsS https://www.basinwx.dev/api/filelist/forecasts | python3 -c '
+import sys,json
+files = json.load(sys.stdin)
+hits = sorted([f for f in files if f.startswith("forecast_hrrr_surface_layers_")])
+print("count:", len(hits), "newest:", hits[-1] if hits else None)
+'
+```
+
+---
+
+## DIAGNOSTIC STEPS (run these BEFORE writing new producers)
+
+```bash
+# 1. What does brc-tools think is the upload destination?
+grep -rn "BASINWX_API_URLS\|basinwx\." --include='*.py' --include='*.sh' --include='*.toml' .
+
+# 2. Which producer scripts already POST to the website?
+grep -rln "x-api-key\|/api/upload/" --include='*.py' .
+
+# 3. Run one of them with --dry-run / -v if available, see what URL it actually hits.
+#    The hypothesis: the observations producer reads BASINWX_API_URLS and fans out;
+#    the clustering/forecasts producer hardcodes www.basinwx.com and doesn't.
+
+# 4. Check the cron table on CHPC for the user that runs these jobs:
+crontab -l | grep -iE "brc|basin|clyfar|hrrr|herbie"
+
+# 5. Are HRRR/clyfar outputs even being generated? (separate question from upload)
+ls -lt $SCRATCH/clyfar_output/basinwx_export/ 2>/dev/null | head
+ls -lt /uufs/chpc.utah.edu/.../forecasts/ 2>/dev/null | head
+# If outputs aren't being produced, the upload work is moot — fix production first.
+```
+
+---
+
+## RECOMMENDED PRODUCTION ORDER (smallest viable first)
+
+1. **Fix fan-out for clustering** — add `.dev` to whatever target list the existing forecasts uploader uses. Verifies the channel without producing new content. ~30 min.
+2. **`forecast_hrrr_kvel_crosswind`** — single point (KVEL), 24-48 forecast hours, two series. Smallest payload of the three. Use this to debug your producer pipeline. ~1-2 days.
+3. **`road-forecast`** — grid points along Uintah Basin road network. More data, but same shape per-point as #2 conceptually. ~2-3 days.
+4. **`forecast_hrrr_surface_layers`** — biggest payload (full surface grid). Schema is already pinned in DATA_MANIFEST.json. Save for last so the smaller producers shake out infrastructure first.
+
+Each producer should use a shared `upload(dataType, filepath)` helper that:
+- reads `BASINWX_API_URLS` once
+- POSTs to each in order, primary then mirrors
+- treats mirror failures as warnings, primary failure as error
+- logs per-target success with timing
+- supports `--dry-run` for dev iteration
+
+---
+
+## ACCEPTANCE CRITERIA
+
+After your work, all of these must succeed:
+
+```bash
+# 1. Existing fan-out repaired:
+curl -fsS https://www.basinwx.dev/api/filelist/forecasts | python3 -c '
+import sys,json; d=json.load(sys.stdin)
+print("clustering files on .dev:", sum(1 for f in d if "clustering_summary" in f))
+'   # > 0
+
+# 2. road-forecast live on both:
+for d in com dev; do
+  curl -fsS "https://www.basinwx.${d}/api/static/road-forecast/latest.json" \
+    | python3 -c 'import sys,json,datetime; o=json.load(sys.stdin)
+age=(datetime.datetime.now(datetime.UTC)-datetime.datetime.fromisoformat(o["init_time"].replace("Z","+00:00"))).total_seconds()/60
+print(f".${d} init_time age: {age:.1f} min")'
+done   # both <180 minutes
+
+# 3. KVEL crosswind page renders:
+#    Visit https://www.basinwx.dev/aviation — table populates with knots data.
+
+# 4. HRRR surface layers visible:
+curl -fsS https://www.basinwx.dev/api/filelist/forecasts | python3 -c '
+import sys,json; d=json.load(sys.stdin)
+print("hrrr surface files on .dev:", sum(1 for f in d if f.startswith("forecast_hrrr_surface_layers_")))
+'   # > 0
+```
+
+---
+
+## ANTI-GOALS — do NOT do these
+
+- ❌ Change the website's `/api/upload/:dataType` route or auth — schema is the contract; everything else is implementation detail you don't control.
+- ❌ Invent new dataTypes (e.g. `road-conditions-v2`) — the website only consumes the eight listed above. New consumers require a website-side PR first.
+- ❌ Touch observations cadence — that's the only working channel; a regression there blanks the live map.
+- ❌ Squash all producers into one mega-script — each forecast type has its own data dependencies (HRRR vs GEFS vs Synoptic). Share the `upload()` helper, not the production logic.
+- ❌ Strip the Kelvin → °C conversion in HRRR pipelines — website unit tests confirm °C and the per-merge sanity check is `273 K → 524°F` if you regress.
+- ❌ Skip `--dry-run`/test-fixture support — the website team will need to seed test data when you're not around.
+
+---
+
+## OPEN QUESTIONS (answer with the human before writing code)
+
+1. **Where is the existing observations uploader?** That's the canonical "good" example to copy — fan-out works, hostname header set correctly, etc. Find it first.
+2. **Is `road-forecast` produced from HRRR-native or post-processed?** The schema assumes 2 m / 10 m / 1-hr precip / surface visibility — all native HRRR fields. If you're going through a different model (NAM, RAP), document the deviation in the JSON's optional `model` field.
+3. **What's the runway naming convention at KVEL?** Verify against current FAA chart before hardcoding `rwy16/rwy34` series tags.
+4. **Where does brc-tools' python env keep `DATA_UPLOAD_API_KEY`?** Should be in a `.env` or shell profile, never in the repo. If absent, get from the human.
+
+---
+
+## REFERENCES (paths in the ubair-website repo)
+
+| File | Lines | Why |
+|---|---|---|
+| `server/routes/dataUpload.js` | 30-40 | dataTypeMap (the 8 accepted dataTypes) |
+| `server/routes/dataUpload.js` | 95-135 | CHPC origin validation logic |
+| `server/routes/dataUpload.js` | 141 | route + multer field name `file` |
+| `server/routes/dataUpload.js` | 188-195 | road-forecast latest.json side-effect |
+| `server/roadWeatherService.js` | 368-431 | road-forecast schema (loadHRRRForecast + getHRRRConditionAtPoint) |
+| `public/js/aviation.js` | 1-100 | KVEL crosswind consumer |
+| `DATA_MANIFEST.json` | 247-629 | forecasts schemas (canonical for hrrr_surface_layers; clyfar variants) |
+| `DATA_MANIFEST.json` | 487-610 | hrrr_surface_layers schema specifically |
+| `CLAUDE.md` | "Data Pipeline" + "Recent Updates" | repository context including fan-out + PR #178 |
+
+---
+
+## END
+
+When you've completed the four acceptance criteria, post back to the human with:
+- the producer script paths (so they can be reviewed)
+- the cron entries you added/changed
+- a curl-based proof for each criterion above
+- any deviation from this contract, with rationale

--- a/docs/AGENT-INDEX.md
+++ b/docs/AGENT-INDEX.md
@@ -1,130 +1,70 @@
-# AI Agent Quick Reference - ubair-website
+# Agent Index — ubair-website
 
-**Current Task:** Dec 1 launch prep - CHPC/Akamai sync verification
-**Status:** Code deployed to ops, awaiting CHPC cron verification
-**Last Session:** 2025-11-27
-**Branch:** `integration-clyfar-v0.9.5`
+Entry point for AI agents working in this repo. **Last refreshed:** 2026-04-27.
 
----
+This file lists what's in `docs/` so you can pick the right reference without grepping the
+whole tree (~13k lines). Read on demand; do not auto-load.
 
-## Quick Start
+## Always-on context (already in your prompt)
+- `CLAUDE.md` (repo root) — topology, pipeline, dataTypes, protected branches, secrets policy, naming convention
+- `MEMORY.md` (per-user, if present) — durable user-specific facts
 
-**Resume after compact:**
-```
-Read: SESSION-27NOV2025.md (latest session - MOST IMPORTANT)
-Read: CRON-SETUP-27NOV2025.md (CHPC crontab setup)
-Verify: CHPC cron running, data flowing to basinwx.com
-```
+## Read first when…
+| Goal | File |
+|---|---|
+| Deploy a fresh box / chase a cert problem | `docs/DEPLOYMENT.md` |
+| Understand the data pipeline end-to-end | `docs/DATA-PIPELINE-OVERVIEW.md` + `DATA_MANIFEST.json` |
+| Author a new ozone outlook | `docs/SOP-outlook-upload.md` |
+| Add a per-user preview branch | `docs/howto/preview-a-branch.md` |
+| Onboard a new RA | `docs/QUICK-START.md` then `docs/howto/quinten-handoff.md` |
+| Plumb new forecast dataType from brc-tools | `WEBSITE-BRCTOOLS-HANDOFF-apr27.md` (root, temporary) |
+| Add or change a frontend page | `docs/FRONTEND-ARCHITECTURE.md` + `docs/JAVASCRIPT-PATTERNS.md` |
+| Touch the camera scheduler | `docs/CAMERA_ANALYSIS_SCHEDULER.md` + `docs/CONFIDENCE_TAXONOMY.md` |
+| Fix a road weather bug | `docs/ROADS_AUDIT.md` + `docs/ROAD_WEATHER_IMPROVEMENTS.md` |
 
-**Key Documentation:**
-1. `SESSION-27NOV2025.md` - Latest session summary (27 Nov)
-2. `CRON-SETUP-27NOV2025.md` - CHPC crontab and paths
-3. `CHPC-IMPLEMENTATION.md` - Deployment master guide
-4. `SESSION-SUMMARY-2025-11-23.md` - Earlier session
-5. `COMPACT-RESUME-POINT.md` - Original context
+## Reference docs (cite, don't reread)
+| Topic | File | Notes |
+|---|---|---|
+| Forecast JSON schemas | `DATA_MANIFEST.json` | canonical contract; brc-tools is contract-holder |
+| Manifest evolution | `docs/MANIFEST-CHANGELOG.md` + `docs/MANIFEST-GUIDE.md` | append-only changelog + how-to |
+| API key + auth | `docs/API-KEY-SETUP.md` | upload route's `x-api-key` |
+| Secret sharing | `docs/SECRET-SHARING-GUIDE.md` | password-manager workflow |
+| SSL / TLS | `docs/SSL-SETUP.md` | Let's Encrypt setup; renewal lives in `DEPLOYMENT.md` |
+| Branching | `docs/BRANCHING-WORKFLOW.md` | (overlaps `BRANCHING-STRATEGY-IMPLEMENTATION.md` — see review) |
+| PR review template | `docs/PR-REVIEW-PROMPT-TEMPLATE.md` | use with the `/ultrareview` flow |
+| Test data | `docs/TEST-DATA.md` + `docs/TESTING-PLAN.md` | seed JSON for local dev |
+| Winter ozone science | `docs/WINTER-OZONE-SCIENCE.md` | for context on why the site exists |
+| Easter eggs / 90s mode | `docs/EASTER-EGGS.md` | Konami code, kiosk, etc. |
+| CHPC/Python side | `docs/python-side-CLAUDE.md` | meant to be **copied** to brc-tools repo as its `CLAUDE.md` |
+| CHPC deployment | `docs/CHPC-DEPLOYMENT.md` + `docs/CHPC-IMPLEMENTATION.md` | (overlapping pair — see review) |
+| Python packaging | `docs/PYTHON-PACKAGING-DEPLOYMENT.md` | brc-tools install/upgrade flow |
 
----
+## Outstanding-work indices (don't trust dates blindly — verify each item)
+- `docs/IMPROVEMENTS.md` — top-level "20 low-hanging fruit" list (refreshed 2026-04-27)
+- `docs/TODO-DEFERRED.md` — Clyfar-integration carry-over from Nov 2025
+- `docs/WISHLIST-TODOS.md` — long-tail aspirations
+- `docs/DEPLOYMENT-SPECS-TODO.md` — deployment-specific
+- `docs/PYTHON-DEVELOPER-TODO.md` — brc-tools-side gaps
+- `docs/ROAD_WEATHER_IMPROVEMENTS.md` — feature-area-specific (older, partly done)
+- `REVIEW-DOCS-apr27.md` (root, temporary) — meta-doc consolidating which of the above to merge
 
-## Critical Context
+## Howto/ subdir
+| File | When |
+|---|---|
+| `docs/howto/preview-a-branch.md` | spinning up `<name>.basinwx.dev` |
+| `docs/howto/avoiding-dev-domain-block.md` | when `.dev` is SNI-filtered on a network |
+| `docs/howto/quinten-handoff.md` | RA onboarding pattern |
 
-### Data Architecture
-- **3 data products:** Possibility (31 files) + Exceedance (1 file) + Percentiles (31 files)
-- **4 categories:** background, moderate, elevated, extreme (NOT 5!)
-- **Schedule:** 4× daily (00:30, 06:30, 12:30, 18:30 UTC)
-- **Total files:** 63 JSON files per forecast run
+## Archive/
+`docs/archive/` holds session handoffs and superseded plans from Nov–Dec 2025. Do not read
+unless tracing decision history.
 
-### Repository Coordination
-1. **ubair-website** (this repo) - Node.js website, receives data
-2. **brc-tools** - Python data tools, shared package
-3. **clyfar** - Ozone prediction model
-4. **preprint-clyfar-v0p9** - LaTeX tech report (4th repo!)
+## Doc-naming convention (also in `CLAUDE.md`)
+- LLM-produced markdown: ALL-CAPS, 3–4 hyphen-separated words.
+- Temporary/handoff docs: append `-mmmDD` before the extension (e.g. `-apr27`).
+- Markdown only — Python and other code follow the language's convention.
 
-### What's Complete (27 Nov Session)
-- ✅ Homepage launch message (Dec 1 announcement)
-- ✅ Coming Soon overlays on all unfinished pages
-- ✅ Server filelist.json path bug fixed
-- ✅ UBAIR ozone stations added to brc-tools
-- ✅ Clyfar script paths corrected
-- ✅ Code merged to dev and ops branches
-- ✅ CHPC crontab documented
-
-### What's Next
-- ⏳ Verify CHPC cron is running (check ~/logs/obs.log)
-- ⏳ Verify data appearing on basinwx.com
-- ⏳ Test Clyfar manual run on CHPC
-- ⏳ Upload outlook markdown via API
-
----
-
-## Common Tasks
-
-**Update schema:**
-```
-File: DATA_MANIFEST.json
-Status: v1.1.0 started but incomplete
-Action: Complete forecast schema with 4 categories
-```
-
-**Test integration:**
-```bash
-cd /Users/johnlawson/PycharmProjects/clyfar
-conda activate clyfar-2025
-python test_integration.py
-```
-
-**Check package install:**
-```bash
-conda activate clyfar-2025
-python -c "from brc_tools.download.push_data import send_json_to_server; print('OK')"
-```
-
----
-
-## Avoid Common Pitfalls
-
-❌ Don't use 5 categories (old assumption)
-❌ Don't aggregate across members (wrong approach)
-❌ Don't assume twice daily (it's 4× now)
-❌ Don't hardcode paths (deployment-ready code)
-❌ Don't re-read files unnecessarily (token waste)
-
-✅ Use 4 categories from fis/v0p9.py
-✅ Export per-member data (63 files)
-✅ Schedule at 4× daily
-✅ Use environment variables and configs
-✅ Reference docs, use Task agents
-
----
-
-## File Locations
-
-**Implementation guides:**
-- Deployment: `CHPC-IMPLEMENTATION.md`
-- Packaging: `PYTHON-PACKAGING-DEPLOYMENT.md`
-- Integration: `../clyfar/INTEGRATION_GUIDE.md`
-
-**Schema:**
-- Data manifest: `DATA_MANIFEST.json` (v1.1.0 in progress)
-- Tech report: `/Users/johnlawson/Documents/GitHub/preprint-clyfar-v0p9`
-
-**Code:**
-- Upload module: `../clyfar/export/to_basinwx.py` (needs rewrite)
-- Test suite: `../clyfar/test_integration.py`
-- Website API: `server/routes/dataUpload.js`
-
----
-
-## Cross-Repo Coordination
-
-**When changing Clyfar config:**
-1. Check Python code (source of truth)
-2. Check tech report (methodology)
-3. Update markdown docs (deployment)
-4. Create CONTRADICTIONS-REPORT.md if mismatches found
-
-**Sync workflow:** See CROSS-REPO-SYNC.md (to be created Phase 2)
-
----
-
-**Last Updated:** 2025-11-23 (pre-compact)
-**Next Review:** After Phase 1 completion
+## Known gaps (as of 2026-04-27)
+- `docs/AGENT-INDEX.md` was 5 months stale before this refresh; treat the rest of `docs/` with
+  the same caution and verify dates before trusting content.
+- See `REVIEW-DOCS-apr27.md` for the consolidation backlog.

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -1,92 +1,84 @@
-# 20 Low-Hanging Fruit Improvements
-# NOTE THIS HAS BEEN HALF DONE AND I NEED TO RENEW IT! - JRL
-## Quick Fixes (Can implement immediately)
+# Improvements & Outstanding Work
 
-### 1. Remove duplicate weather file
-**Issue:** `forecast_weather_old.js` is unused
-**Fix:** `rm public/js/forecast_weather_old.js`
+**Last refreshed:** 2026-04-27 (was flagged "half done — JRL needs to renew" — full reset).
+**Source:** ground-truth grep against `dev` HEAD a14fd93 + this session's review.
 
-### 2. Add missing error boundaries
-**Issue:** API failures crash pages
-**Fix:** Add try/catch blocks around fetch calls
+This list is for medium-leverage cleanups and low-risk improvements. For larger product
+work, use GitHub Issues. For temporary handoffs, use a dated `*-apr27.md` doc.
 
-### 3. Standardize console logging
-**Issue:** Mix of console.log/console.error
-**Fix:** Use consistent logging levels
+Statuses: 🔜 pending · 🔄 in-progress · ✅ done · ⏸️ deferred (decision blocked)
 
-### 4. Add loading states
-**Issue:** Maps show blank while loading data
-**Fix:** Add "Loading..." indicators
+---
 
-### 5. Fix favicon missing error
-**Issue:** Browser shows 404 for favicon
-**Fix:** Add favicon.ico to public folder
+## Operational health (highest priority)
 
-### 6. Optimize image loading
-**Issue:** Large images load slowly
-**Fix:** Add lazy loading and WebP versions
+| ✓ | Item | Notes |
+|---|---|---|
+| 🔜 | **Promote `dev` → `ops`** to land 21 commits on `.com` | PRs #142, #178–#188 plus 7 fixes; needs a deliberate `dev→ops` PR + `pm2 restart basinwx-ops` |
+| 🔜 | **Fix three dark dataTypes** (road-forecast, kvel_crosswind, hrrr_surface_layers) | brc-tools side; full handoff in `WEBSITE-BRCTOOLS-HANDOFF-apr27.md` |
+| 🔜 | **Fan-out gap for `forecasts/` to `.dev`** | `.com` has 100s of clustering files, `.dev` has zero. brc-tools uploader inconsistency. |
+| 🔜 | **Operational health page** (`/admin/health`) | per-dataType last-upload time + expected cadence + pm2 uptime + git HEAD; tier-3 of the apr26 plan |
+| 🔜 | **Upload-freshness alarm** | cron walks `public/api/static/`, emails via `reportEmailService` if any dataType exceeds expected cadence |
 
-### 7. Add metadata to HTML pages
-**Issue:** Missing SEO meta tags
-**Fix:** Add description, keywords, OpenGraph tags
+## Code quality
 
-### 8. Fix hardcoded localhost URLs
-**Issue:** Won't work on production
-**Fix:** Use relative URLs or environment variables
+| ✓ | Item | Notes |
+|---|---|---|
+| 🔜 | **Fix 4 failing tests** in `server/__tests__/cameraAnalysisScheduler.test.js` | Test drift after scheduler default changes (expected 25, got 30; expected 432, got 360). Don't add features on top of red tests. |
+| 🔜 | **Security deps PR** | `nodemailer ^6→^7` (advisory `<7.0.7`), `node-cron ^3→^4` (transitively fixes uuid), `@github/copilot` to current. 5 GH-reported vulns. |
+| 🔜 | **Pick a logger and burn down 178 `console.log`s** | Recommend `pino`. One file at a time, lowest-risk first (`scripts/`, then `server/`). |
+| 🔜 | **Standardise error boundaries on fetch calls** | API failures still cascade in places. Try/catch + user-visible loading/error state. |
+| 🔜 | **Data validation on incoming JSON** | server doesn't enforce `DATA_MANIFEST.json` schemas; malformed brc-tools uploads can crash visualisations. Tier 3 contract test would catch this. |
 
-### 9. Add ARIA accessibility labels
-**Issue:** Screen readers can't navigate maps
-**Fix:** Add proper ARIA labels to interactive elements
+## Frontend
 
-### 10. Standardize button styling
-**Issue:** Inconsistent button appearance
-**Fix:** Create unified button classes in main.css
+| ✓ | Item | Notes |
+|---|---|---|
+| 🔜 | **CSS consolidation** | 30 files (was 13 when this list was first written). Aim for `core/` (variables, base, layout) + `pages/` ≤12 files total. The `fire.css↔fire.html` 1:1 mapping is fine for page-specific styles. |
+| 🔜 | **Favicon** | `/favicon.ico` at root still missing → browser 404 on every load. Multiple files exist in `/public/images/favicons/`; pick one and copy to root. |
+| 🔜 | **ARIA labels on map controls** | screen readers can't navigate the Leaflet maps |
+| 🔜 | **Loading states on every map** | "Loading…" indicator while initial fetch runs |
+| 🔜 | **Print-friendly styles** | `@media print` rules; low priority |
+| ✅ | **Last-updated timestamps in UI** | partly done — visible in `DataCache.js`, `uiManager.js`, road weather panels. Audit other pages for parity. |
+| ✅ | **Remove `forecast_weather_old.js`** | no longer present in `public/js/` |
+| ✅ | **Hardcoded localhost** | only remaining instance is the server boot log message (`server.js:194`), which is correct for stdout |
 
-## Medium Priority Improvements
+## Data pipeline & schema
 
-### 11. Add data refresh timestamps
-**Issue:** Users don't know how old data is
-**Fix:** Display "Last updated: X minutes ago"
+| ✓ | Item | Notes |
+|---|---|---|
+| 🔜 | **Add `road-forecast` schema to `DATA_MANIFEST.json`** | currently undocumented dataType; brc-tools is the contract-holder but website-side manifest is where consumers look |
+| 🔜 | **Add `forecast_hrrr_kvel_crosswind_*` schema to `DATA_MANIFEST.json`** | extracted in `WEBSITE-BRCTOOLS-HANDOFF-apr27.md` §DATATYPE 2; copy-pin |
+| 🔜 | **CHPC↔website contract test** | small CI/cron job that POSTs synthetic JSON for every dataType, verifies it lands; would have caught the dark-dataTypes regression |
 
-### 12. Implement error retry logic
-**Issue:** Single API failure breaks functionality
-**Fix:** Add automatic retry with exponential backoff
+## Documentation hygiene (see `REVIEW-DOCS-apr27.md`)
 
-### 13. Add keyboard navigation
-**Issue:** Can't use tab/enter on map controls
-**Fix:** Add proper keyboard event handlers
+| ✓ | Item | Notes |
+|---|---|---|
+| 🔜 | **Merge `BRANCHING-WORKFLOW.md` + `BRANCHING-STRATEGY-IMPLEMENTATION.md`** | confirmed overlap; pick one |
+| 🔜 | **Merge `CHPC-DEPLOYMENT.md` + `CHPC-IMPLEMENTATION.md`** | confirmed overlap |
+| 🔜 | **Resolve `API_RATE_CALCULATIONS*.md` pair** | one is "current", one is "proposed hybrid"; archive the one that's not reality |
+| 🔜 | **Collapse 5 TODO docs into one** | `IMPROVEMENTS.md` (this file) + `TODO-DEFERRED.md` + `WISHLIST-TODOS.md` + `DEPLOYMENT-SPECS-TODO.md` + `PYTHON-DEVELOPER-TODO.md` |
+| 🔜 | **Bulk-rename underscored filenames to hyphens** | per the new naming convention; cosmetic chore PR |
+| 🔜 | **Move `CRON-SETUP-27NOV2025.md` to `archive/`** | date-stamped, superseded |
+| 🔜 | **Expand `docs/README.md`** | currently a 17-line stub; should be the human-side counterpart of `docs/AGENT-INDEX.md` |
+| ✅ | **Refresh `docs/AGENT-INDEX.md`** | was 5 months stale; rewritten 2026-04-27 |
+| ✅ | **Trim `CLAUDE.md` for AI-context efficiency** | 101 → 67 lines; this PR |
+| ✅ | **Trim `README.md` for human reader** | 248 → ~110 lines; this PR |
 
-### 14. Optimize bundle size
-**Issue:** Loading multiple large libraries
-**Fix:** Use tree-shaking, load libraries conditionally
+## Deferred / decision-blocked
 
-### 15. Add data validation
-**Issue:** Malformed data crashes visualizations
-**Fix:** Validate JSON schema before processing
+| ✓ | Item | Notes |
+|---|---|---|
+| ⏸️ | **Service worker for offline viewing** | nice-to-have; not blocking anything; defer until product priorities clearer |
+| ⏸️ | **Bundle-size optimisation / tree-shaking** | vanilla JS, mostly fine; revisit if a perf complaint surfaces |
+| ⏸️ | **API retry with exponential backoff** | UX-mediocre on flaky networks but no incident yet; defer |
+| ⏸️ | **Migration of SOPs to GitHub Wiki** | per `docs/README.md`'s standing TODO; revisit when team size justifies |
 
-### 16. Implement caching
-**Issue:** Repeated API calls slow performance
-**Fix:** Add client-side caching with TTL
+---
 
-### 17. Add unit labels consistency
-**Issue:** Some values show units, others don't
-**Fix:** Ensure all measurements display units
-
-### 18. Fix map marker clustering
-**Issue:** Overlapping stations hard to click
-**Fix:** Group nearby stations when zoomed out
-
-## Future Enhancements
-
-### 19. Add print-friendly styles
-**Issue:** Pages don't print well
-**Fix:** Add @media print CSS rules
-
-### 20. Implement offline functionality
-**Issue:** No internet = broken site
-**Fix:** Add service worker for basic offline viewing
-
-## Implementation Priority
-1. **Do first:** Items 1, 5, 8, 10 (5 minutes each)
-2. **Do next:** Items 2, 4, 7, 11 (15 minutes each)
-3. **Do later:** Items 6, 12, 14, 18 (30+ minutes each)
+## How to use this list
+- Pick an item. Verify it's still real (run the probe in the notes column or grep). Open a PR.
+- When done, change 🔜 to ✅ and commit the status update with the work.
+- If you find an item is no longer relevant, change to ✅ with a one-line note ("not reproducible 2026-mm-dd") and move on.
+- Don't grow this list past ~30 active items — past that, file GitHub Issues.


### PR DESCRIPTION
## Summary
- Trim auto-loaded \`CLAUDE.md\` from 101 → 67 lines. Removes bring-up lore (duplicated in \`docs/DEPLOYMENT.md\`), stale \"Recent Updates\" section, and \"Known Issues\" with outdated counts (CSS=13→30, console.log=122→178). Keeps load-bearing facts: topology, data pipeline, dataTypes, protected-branch rule, secrets policy.
- Add doc-naming convention for LLM-produced markdown: ALL-CAPS, 3–4 words; temporary docs append \`-mmmDD\` before extension. Markdown only; code files follow language convention.
- Land \`WEBSITE-BRCTOOLS-HANDOFF-apr27.md\` as a temporary artefact exemplifying the new convention. Documents the JSON contracts, upload endpoint, and acceptance criteria for the three dark dataTypes (\`road-forecast\`, \`forecast_hrrr_kvel_crosswind_*\`, \`forecast_hrrr_surface_layers_*\`) merged in PRs #176/#183/#188 but never produced or uploaded by brc-tools.

## Why
Auto-loaded files cost context on every Claude session. Lore that goes stale on every merge (PR #182 shipped 3 days ago, already missing the 7 PRs from this session) is worse than a pointer. \`docs/DEPLOYMENT.md\` and \`git log\` are authoritative; CLAUDE.md should index them, not duplicate them.

## Test plan
- [ ] Read CLAUDE.md fresh — every section either load-bearing for a new agent or a pointer to a deeper doc
- [ ] \`docs/DEPLOYMENT.md\` still covers what was removed (firewall, certbot --manual trap, SNI filter, pm2 startup) — yes, those bullets came from there originally
- [ ] After merge, pull on another box and confirm \`CLAUDE.md\` is the trimmed version

🤖 Generated with [Claude Code](https://claude.com/claude-code)