### PR TITLE
docs(manifest): add road-forecast dataType entry

### DIFF
--- a/DATA_MANIFEST.json
+++ b/DATA_MANIFEST.json
@@ -643,6 +643,135 @@
         "Daily maximum values are used (local timezone: America/Denver)",
         "Forecast horizon: ~15-17 days depending on GEFS availability"
       ]
+    },
+    "road-forecast": {
+      "description": "HRRR road-weather forecast at fixed waypoints along Uinta Basin highway corridors. Produced by brc-tools (python -m brc_tools.download.get_road_forecast); consumed by server/roadWeatherService.js getHRRRConditionAtPoint to drive /api/road-weather/forecast and the road weather map.",
+      "format": "json",
+      "endpoint": "/api/upload/road-forecast",
+      "schedule": {
+        "frequency": "ad-hoc (proof-of-concept)",
+        "description": "Manual runs from CHPC during development. Cron schedule TBD; expected hourly once promoted out of POC.",
+        "timezone": "UTC",
+        "automation": "manual"
+      },
+      "filename": {
+        "pattern": "road_forecast_YYYYMMDD_HHMMZ.json",
+        "example": "road_forecast_20260428_0520Z.json",
+        "latestSymlink": "public/api/static/road-forecast/latest.json (server copies on upload — see dataUpload.js)"
+      },
+      "schema": {
+        "type": "object",
+        "required": ["model", "init_time", "points"],
+        "properties": {
+          "model": {
+            "type": "string",
+            "enum": ["hrrr"]
+          },
+          "product": {
+            "type": "string",
+            "description": "HRRR product variant",
+            "enum": ["sfc", "subh"]
+          },
+          "init_time": {
+            "type": "string",
+            "description": "HRRR initialization time (ISO 8601 with Z). Rejected by roadWeatherService.loadHRRRForecast if older than 3 hours.",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+          },
+          "generated_at": {
+            "type": "string",
+            "description": "Build wall-clock time (ISO 8601 with Z)",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+          },
+          "forecast_hours": {
+            "type": "array",
+            "items": { "type": "integer", "minimum": 0 }
+          },
+          "valid_times": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+            }
+          },
+          "variables": {
+            "type": "object",
+            "description": "Variable metadata (display label + units)"
+          },
+          "points": {
+            "type": "array",
+            "description": "Flat list of forecast waypoints. Read by getHRRRConditionAtPoint via nearest-neighbor on lat/lon.",
+            "items": {
+              "type": "object",
+              "required": ["lat", "lon", "forecasts"],
+              "properties": {
+                "route_id": {
+                  "type": "string",
+                  "enum": ["us40", "us191", "basin_roads"]
+                },
+                "name": { "type": "string" },
+                "lat": { "type": "number" },
+                "lon": { "type": "number" },
+                "elevation_m": { "type": ["number", "null"] },
+                "reference_stid": { "type": ["string", "null"] },
+                "forecasts": {
+                  "type": "array",
+                  "description": "Per-forecast-step values. Website currently reads index 0 only; full series future-proofs for downstream use.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "valid_time": {
+                        "type": "string",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+                      },
+                      "temp_2m": { "type": ["number", "null"], "description": "Celsius" },
+                      "wind_speed_10m": { "type": ["number", "null"], "description": "m/s" },
+                      "wind_gust": { "type": ["number", "null"], "description": "m/s" },
+                      "visibility": { "type": ["number", "null"], "description": "km (server multiplies by 1000 for metres)" },
+                      "precip_1hr": { "type": ["number", "null"], "description": "mm" },
+                      "precip_type": {
+                        "type": ["string", "null"],
+                        "enum": [null, "none", "snow", "rain", "freezing_rain", "ice_pellets", "mixed"]
+                      },
+                      "snow_depth": { "type": ["number", "null"], "description": "mm" },
+                      "cloud_cover": { "type": ["number", "null"], "description": "%" },
+                      "rh_2m": { "type": ["number", "null"], "description": "%" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "routes": {
+            "type": "object",
+            "description": "Legacy nested-by-route shape preserved for backward compatibility. Per-variable arrays keyed by route_id then waypoint_index. New consumers should read points[] instead."
+          },
+          "cameras": {
+            "type": "array",
+            "description": "Reserved for future camera integration; emitted empty today."
+          }
+        }
+      },
+      "validation": {
+        "maxFileSize": "1MB",
+        "maxAgeHours": 3,
+        "expectedPointCount": 17,
+        "unitMapping": {
+          "temp_2m": "Celsius",
+          "wind_speed_10m": "m/s",
+          "wind_gust": "m/s",
+          "visibility": "km",
+          "precip_1hr": "mm",
+          "snow_depth": "mm",
+          "cloud_cover": "%",
+          "rh_2m": "%"
+        }
+      },
+      "notes": [
+        "Server copies the upload to public/api/static/road-forecast/latest.json on success (server/routes/dataUpload.js line 188-193).",
+        "loadHRRRForecast rejects files with init_time older than 3 hours (server/roadWeatherService.js line 383-389).",
+        "Currently 17 waypoints across 3 corridors (9 us40 + 4 us191 + 4 basin_roads). Densification is a possible future upgrade.",
+        "Producer: brc-tools brc_tools.download.get_road_forecast (proof-of-concept; not yet on a cron)."
+      ]
     }
   },
   "globalValidation": {


### PR DESCRIPTION
## Summary
- Adds a `road-forecast` entry to `DATA_MANIFEST.json` documenting the contract that `server/roadWeatherService.js` already consumes (PR #188 introduced the consumer; this PR documents the producer/consumer contract).
- Captures the flat `points[]` shape (matches the brc-tools producer at https://github.com/Bingham-Research-Center/brc-tools/pull/21).
- Notes the legacy `routes{}` field is preserved for backward compatibility but new consumers should read `points[]`.
- Documents the 3-hour staleness gate (`server/roadWeatherService.js:383-389`) and the `latest.json` side-effect (`server/routes/dataUpload.js:188-193`).

## Why
The road-forecast pipeline is currently undocumented in DATA_MANIFEST.json even though both producer (brc-tools `get_road_forecast`) and consumer (`getHRRRConditionAtPoint`) are live. Documenting the schema now closes the loop and gives future contributors a single source of truth for the contract.

## Producer side
Open at https://github.com/Bingham-Research-Center/brc-tools/pull/21 — emits 17 waypoints across 3 corridors with units matching what the website expects (temp °C, wind m/s, visibility km, precip mm).

## Test plan
- [x] `jq -e '.dataTypes["road-forecast"]' DATA_MANIFEST.json` confirms valid JSON + entry present.
- [ ] Reviewer eyeball: schema accurately reflects what `getHRRRConditionAtPoint` reads at `server/roadWeatherService.js:399-428`.
- [ ] Reviewer eyeball: schedule wording ("ad-hoc proof-of-concept") accurately reflects current state — update once a cron is wired up on notchpeak1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)