### PR TITLE
feat(fire): live /fire page (HDW, restrictions, fire tracking)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ DATA_UPLOAD_API_KEY=your_generated_api_key_here
 UDOT_API_KEY=your_udot_api_key_here             # [shared]   https://www.udottraffic.utah.gov/
 SYNOPTIC_API_TOKEN=your_synoptic_token_here     # [shared]   https://synoptic.utah.edu/
 # SYNOPTIC_API_KEY=                             # [optional] alias — code accepts either KEY or TOKEN
+FIRMS_MAP_KEY=                                  # [shared]   https://firms.modaps.eosdis.nasa.gov/api/map_key/ — used by /fire page hotspot layer; if blank, hotspots silently degrade to empty list
 
 # BASE_URL=http://localhost:3000                # [optional] only used by scripts/test-api.js in local dev
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ package-lock.json
 .env.local
 .env.*.local
 
+# API key material (never commit raw key files)
+server/keys/
+*.key
+
 # IDE specific files
 .idea/
 .vscode/

--- a/public/css/fire.css
+++ b/public/css/fire.css
@@ -305,3 +305,679 @@ body[data-page-type="fire"] h1::after {
     outline: 2px solid var(--fire-accent);
     outline-offset: 2px;
 }
+
+/* ===========================================================
+   Fire Weather v1 additions (below the original placeholder
+   styles). Hero, HDW badge, Red Flag banner, map + hotspots,
+   forecast strip, preparedness, resources, loading.
+   =========================================================== */
+
+/* Red Flag banner */
+.red-flag-banner {
+    background: linear-gradient(135deg, #7d0000, var(--fire-warning));
+    color: white;
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 6px 20px rgba(125, 0, 0, 0.3);
+    animation: pulse-red-strong 2s ease-in-out infinite;
+}
+.red-flag-banner.is-hidden,
+.red-flag-banner[hidden] { display: none; }
+.red-flag-card { background: rgba(255, 255, 255, 0.12); border-radius: 8px; padding: 0.75rem 1rem; margin-bottom: 0.5rem; }
+.red-flag-card:last-child { margin-bottom: 0; }
+.red-flag-card-head { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.red-flag-card-head strong { font-size: 1.05rem; }
+.red-flag-area { flex: 1 1 auto; font-size: 0.9rem; opacity: 0.95; }
+.red-flag-expires { font-size: 0.85rem; opacity: 0.85; }
+.red-flag-card details summary { cursor: pointer; padding: 0.4rem 0; font-weight: 500; }
+.red-flag-instruction { background: rgba(0, 0, 0, 0.18); padding: 0.5rem 0.75rem; border-radius: 4px; margin-top: 0.5rem; }
+
+@keyframes pulse-red-strong {
+    0%, 100% { box-shadow: 0 6px 20px rgba(125, 0, 0, 0.3); }
+    50%      { box-shadow: 0 6px 32px rgba(255, 0, 0, 0.55); }
+}
+
+/* Hero */
+.fire-hero {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1.5rem 2rem;
+    background: linear-gradient(135deg, white, #fff8f0);
+    border-radius: 16px;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 6px 25px rgba(178, 34, 34, 0.08);
+    border-left: 6px solid var(--fire-primary);
+}
+.hero-hdw { display: flex; flex-direction: column; gap: 0.4rem; align-items: flex-start; }
+.hdw-label { font-size: 0.8rem; text-transform: uppercase; color: var(--fire-smoke); letter-spacing: 0.05em; }
+.hdw-level-badge {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding: 0.5rem 1.1rem;
+    border-radius: 10px;
+    font-weight: 700;
+    color: white;
+    background: var(--fire-smoke);
+    transition: background 0.4s ease;
+}
+.hdw-level-badge[data-level="loading"] { background: #888; }
+.hdw-level-badge[data-level="low"]       { background: #2d6b3a; }
+.hdw-level-badge[data-level="moderate"]  { background: #b08600; }
+.hdw-level-badge[data-level="high"]      { background: #b85a00; }
+.hdw-level-badge[data-level="very_high"] { background: #a82632; }
+.hdw-level-badge[data-level="extreme"]   { background: #5a0000; box-shadow: 0 0 12px rgba(255, 0, 0, 0.35); }
+.hdw-value { font-size: 2.2rem; line-height: 1; }
+.hdw-level-name { font-size: 1.05rem; opacity: 0.95; }
+.hdw-source { font-size: 0.78rem; color: var(--fire-smoke); font-style: italic; }
+.hero-side { display: flex; flex-direction: column; align-items: flex-end; gap: 0.6rem; flex: 1; }
+.hero-snapshot { color: #444; font-size: 1rem; text-align: right; margin: 0; }
+.hotspot-count-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    background: #fff0e0;
+    color: var(--fire-primary);
+    border: 1px solid var(--fire-accent);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+.hotspot-count-chip i { color: var(--fire-warning); }
+.hotspot-count-chip.is-hidden,
+.hotspot-count-chip[hidden] { display: none; }
+
+/* Map section */
+.map-section {
+    background: white;
+    border-radius: 16px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 6px 25px rgba(178, 34, 34, 0.08);
+    border: 1px solid rgba(178, 34, 34, 0.1);
+}
+.map-section h2 {
+    color: var(--fire-primary);
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.map-section h2 i { color: var(--fire-secondary); }
+.station-map {
+    width: 100%;
+    height: 480px;
+    border-radius: 12px;
+    box-shadow: 0 4px 18px rgba(178, 34, 34, 0.12);
+}
+.map-legend-text {
+    font-size: 0.85rem;
+    color: #666;
+    margin-top: 0.75rem;
+}
+
+/* Map markers */
+.fire-station-marker { background: transparent; border: none; }
+.fire-station-pin {
+    width: 34px; height: 34px;
+    border-radius: 50%;
+    border: 2px solid white;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 700;
+    font-size: 0.9rem;
+}
+.fire-hotspot-marker { animation: hotspot-pulse 2.2s ease-in-out infinite; }
+@keyframes hotspot-pulse {
+    0%, 100% { stroke-opacity: 0.9; }
+    50%      { stroke-opacity: 0.45; }
+}
+
+/* Leaflet legend */
+.fire-map-legend {
+    background: rgba(255, 255, 255, 0.95);
+    padding: 0.6rem 0.75rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    font-size: 0.8rem;
+    line-height: 1.4;
+    color: #333;
+}
+.fire-map-legend strong { display: block; margin-bottom: 0.3rem; color: var(--fire-primary); }
+.fire-map-legend .legend-row { display: flex; align-items: center; gap: 0.45rem; margin: 2px 0; }
+.fire-map-legend .legend-swatch {
+    flex: 0 0 14px;
+    width: 14px;
+    height: 14px;
+    min-width: 14px;
+    min-height: 14px;
+    border-radius: 50%;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    box-sizing: border-box;
+    display: inline-block;
+}
+.fire-map-legend .legend-firms-swatch {
+    background: #cc0000;
+    border-color: #660000;
+}
+.fire-map-legend .legend-row-firms { margin-top: 0.35rem; padding-top: 0.35rem; border-top: 1px solid rgba(0, 0, 0, 0.08); }
+
+/* Map popups */
+.fire-popup h4 {
+    margin: 0 0 0.3rem;
+    color: var(--fire-primary);
+    font-size: 1rem;
+}
+.fire-popup .popup-meta { color: #777; font-size: 0.8rem; margin: 0 0 0.4rem; }
+.fire-popup .popup-row { margin: 0.2rem 0; font-size: 0.9rem; color: #333; }
+.popup-badge {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 999px;
+    color: white;
+    font-size: 0.75rem;
+    margin-left: 0.4rem;
+}
+
+/* Forecast strip */
+.forecast-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.75rem;
+}
+.forecast-day-card {
+    background: linear-gradient(135deg, white, #fff8f0);
+    padding: 1rem 0.75rem;
+    border-radius: 10px;
+    text-align: center;
+    border-top: 3px solid var(--fire-accent);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+.forecast-day-card h3 {
+    font-size: 0.95rem;
+    color: var(--fire-primary);
+    margin: 0 0 0.4rem;
+}
+.forecast-temp {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--fire-secondary);
+    margin: 0.2rem 0;
+}
+.forecast-wind, .forecast-short {
+    font-size: 0.82rem;
+    color: #555;
+    margin: 0.2rem 0;
+}
+
+/* Meteogram */
+.meteogram-chart {
+    width: 100%;
+    height: 420px;
+    background: #fff8f0;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+/* Preparedness */
+.preparedness-section {
+    background: white;
+    border-radius: 16px;
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 6px 25px rgba(178, 34, 34, 0.08);
+    border-left: 4px solid var(--fire-accent);
+}
+.preparedness-section h2 {
+    color: var(--fire-primary);
+    margin-bottom: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.preparedness-section h2 i { color: var(--fire-secondary); }
+.preparedness-grid {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1rem;
+}
+.preparedness-grid li {
+    background: #fff8f0;
+    padding: 1rem 1.1rem;
+    border-radius: 10px;
+    border-left: 3px solid var(--fire-secondary);
+    color: #333;
+    line-height: 1.5;
+}
+.preparedness-grid li strong { color: var(--fire-primary); }
+
+/* Resources */
+.resources-section {
+    margin-bottom: 2rem;
+}
+.resources-section h2 {
+    color: var(--fire-primary);
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.resources-section h2 i { color: var(--fire-secondary); }
+.resources-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+}
+.resource-card {
+    display: block;
+    background: white;
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-decoration: none;
+    color: inherit;
+    border-left: 4px solid var(--fire-primary);
+    box-shadow: 0 4px 14px rgba(178, 34, 34, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.resource-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 22px rgba(178, 34, 34, 0.16);
+}
+.resource-card h3 { color: var(--fire-primary); margin: 0 0 0.3rem; font-size: 1.05rem; }
+.resource-card p { color: #555; font-size: 0.9rem; margin: 0; }
+
+/* Loading spinner */
+.loading-spinner {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    justify-content: center;
+    padding: 2rem;
+    color: var(--fire-smoke);
+    font-size: 0.95rem;
+}
+.loading-spinner i { color: var(--fire-secondary); font-size: 1.2rem; }
+
+/* Active Fire Restrictions */
+.restrictions-section {
+    background: white;
+    border-radius: 16px;
+    padding: 2rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 6px 25px rgba(178, 34, 34, 0.08);
+    border-left: 4px solid var(--fire-primary);
+    position: relative;
+}
+.restrictions-section[hidden] { display: none; }
+.restrictions-section::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, var(--fire-primary), var(--fire-secondary), var(--fire-accent));
+    border-radius: 16px 16px 0 0;
+}
+.restrictions-section h2 {
+    color: var(--fire-primary);
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin: 0 0 0.4rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.restrictions-section h2 i { color: var(--fire-secondary); }
+.restrictions-intro {
+    color: var(--fire-smoke);
+    font-size: 0.85rem;
+    margin: 0 0 1.25rem;
+    line-height: 1.5;
+}
+.restrictions-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1rem;
+}
+.restriction-card {
+    background: linear-gradient(135deg, white, #fff8f0);
+    padding: 1.1rem 1.2rem;
+    border-radius: 12px;
+    border-left: 4px solid var(--fire-primary);
+    box-shadow: 0 4px 14px rgba(178, 34, 34, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+.restriction-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 22px rgba(178, 34, 34, 0.16);
+}
+.restriction-card-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.restriction-agency {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    color: var(--fire-primary);
+}
+.restriction-type-pill {
+    display: inline-block;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: white;
+    background: var(--fire-smoke);
+    white-space: nowrap;
+}
+.restriction-type-pill[data-type^="stage-1"] { background: var(--fire-accent); }
+.restriction-type-pill[data-type^="stage-2"] { background: var(--fire-secondary); }
+.restriction-type-pill[data-type^="stage-3"] { background: var(--fire-warning); }
+.restriction-type-pill[data-type^="prevention"]  { background: var(--fire-primary); }
+.restriction-type-pill[data-type^="special"]     { background: var(--fire-smoke); }
+.restriction-type-pill[data-type^="ordinance"]   { background: var(--fire-smoke); }
+.restriction-area {
+    margin: 0;
+    color: #333;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    font-weight: 500;
+}
+.restriction-meta {
+    margin: 0;
+    color: #666;
+    font-size: 0.8rem;
+}
+.restriction-summary-heading {
+    margin: 0.35rem 0 0.25rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fire-primary);
+}
+.restriction-summary {
+    margin: 0;
+    color: #333;
+    font-size: 0.9rem;
+    line-height: 1.55;
+    padding-left: 0.75rem;
+    border-left: 2px solid var(--fire-secondary);
+}
+.restriction-highlights {
+    margin: 0.4rem 0 0;
+    padding: 0;
+    list-style: none;
+    color: #333;
+    font-size: 0.85rem;
+    line-height: 1.45;
+}
+.restriction-highlights li {
+    position: relative;
+    padding-left: 1.2em;
+    margin: 0.2rem 0;
+}
+.restriction-highlights li::before {
+    content: '▸';
+    position: absolute;
+    left: 0;
+    color: var(--fire-accent);
+    font-weight: 700;
+}
+.restriction-empty {
+    margin: 0.35rem 0;
+    color: var(--fire-smoke);
+    font-size: 0.85rem;
+    font-style: italic;
+    line-height: 1.5;
+}
+.restriction-foot {
+    margin: 0.5rem 0 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+.restriction-order {
+    font-size: 0.72rem;
+    color: var(--fire-smoke);
+    font-variant-numeric: tabular-nums;
+}
+.restriction-link {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background: var(--fire-primary);
+    color: white;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.85rem;
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(178, 34, 34, 0.2);
+    transition: background 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+.restriction-link:hover {
+    background: var(--fire-secondary);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(255, 69, 0, 0.3);
+}
+.restriction-no-link {
+    font-size: 0.8rem;
+    color: var(--fire-smoke);
+    font-style: italic;
+}
+
+/* Detected Fires (auto-clustered FIRMS) */
+.fire-list-section {
+    background: white;
+    border-radius: 16px;
+    padding: 2rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 6px 25px rgba(178, 34, 34, 0.08);
+    border-left: 4px solid var(--fire-primary);
+    position: relative;
+}
+.fire-list-section[hidden] { display: none; }
+.fire-list-section::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, var(--fire-primary), var(--fire-warning), var(--fire-accent));
+    border-radius: 16px 16px 0 0;
+}
+.fire-list-section h2 {
+    color: var(--fire-primary);
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin: 0 0 0.4rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.fire-list-section h2 i { color: var(--fire-secondary); }
+.fire-list-intro {
+    color: var(--fire-smoke);
+    font-size: 0.85rem;
+    margin: 0 0 1.25rem;
+    line-height: 1.5;
+}
+.fire-list-intro strong { color: var(--fire-primary); }
+.fire-list-group { margin-bottom: 1.25rem; }
+.fire-list-group:last-child { margin-bottom: 0; }
+.fire-list-group[hidden] { display: none; }
+.fire-list-group h3 {
+    color: var(--fire-primary);
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin: 0 0 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.fire-list-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.6em;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(178, 34, 34, 0.08);
+    color: var(--fire-primary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+.fire-list-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1rem;
+}
+.fire-card {
+    background: linear-gradient(135deg, white, #fff8f0);
+    padding: 1.1rem 1.2rem;
+    border-radius: 12px;
+    border-left: 4px solid var(--fire-primary);
+    box-shadow: 0 4px 14px rgba(178, 34, 34, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.fire-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 22px rgba(178, 34, 34, 0.16);
+}
+.fire-card-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.fire-card-title {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--fire-primary);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+.fire-status-pill {
+    display: inline-block;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: white;
+    background: var(--fire-smoke);
+    white-space: nowrap;
+}
+.fire-status-pill[data-status="active"] {
+    background: var(--fire-warning);
+    box-shadow: 0 0 0 1px rgba(255, 0, 0, 0.15), 0 0 10px rgba(255, 0, 0, 0.25);
+    animation: fire-pulse 2.4s ease-in-out infinite;
+}
+.fire-status-pill[data-status="recent"] {
+    background: var(--fire-smoke);
+}
+@keyframes fire-pulse {
+    0%, 100% { box-shadow: 0 0 0 1px rgba(255, 0, 0, 0.15), 0 0 10px rgba(255, 0, 0, 0.25); }
+    50%      { box-shadow: 0 0 0 1px rgba(255, 0, 0, 0.25), 0 0 18px rgba(255, 0, 0, 0.45); }
+}
+.fire-card-meta {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: 0.85rem;
+    row-gap: 0.25rem;
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.4;
+}
+.fire-card-meta dt {
+    color: var(--fire-smoke);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.7rem;
+    font-weight: 600;
+    align-self: center;
+}
+.fire-card-meta dd {
+    margin: 0;
+    color: #333;
+    font-variant-numeric: tabular-nums;
+}
+.fire-card-abs {
+    color: var(--fire-smoke);
+    font-size: 0.72rem;
+    font-style: italic;
+    margin-left: 0.25rem;
+}
+.fire-card-foot {
+    margin: 0.15rem 0 0;
+}
+.fire-card-link {
+    color: var(--fire-primary);
+    font-weight: 600;
+    font-size: 0.82rem;
+    text-decoration: none;
+    transition: color 0.15s ease;
+}
+.fire-card-link:hover { color: var(--fire-secondary); }
+
+/* Leaflet cluster circle subtle pulse for active fires */
+.fire-cluster-circle {
+    animation: fire-cluster-pulse 3.2s ease-in-out infinite;
+}
+@keyframes fire-cluster-pulse {
+    0%, 100% { stroke-opacity: 0.9; fill-opacity: 0.18; }
+    50%      { stroke-opacity: 0.55; fill-opacity: 0.10; }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .fire-hero {
+        flex-direction: column;
+        align-items: stretch;
+        padding: 1.2rem 1.25rem;
+    }
+    .hero-side { align-items: flex-start; }
+    .hero-snapshot { text-align: left; }
+    .station-map { height: 360px; }
+    .meteogram-chart { height: 340px; }
+    .restrictions-section { padding: 1.5rem 1.25rem; }
+    .restrictions-list { grid-template-columns: 1fr; }
+    .restriction-foot { flex-direction: column-reverse; align-items: stretch; }
+    .restriction-link { justify-content: center; }
+    .fire-list-section { padding: 1.5rem 1.25rem; }
+    .fire-list-grid { grid-template-columns: 1fr; }
+}

--- a/public/js/fire/AlertsBanner.js
+++ b/public/js/fire/AlertsBanner.js
@@ -1,0 +1,38 @@
+/* NWS Red Flag / Fire Weather alert banner.
+   Uses aria-live="polite" via the static markup so screen readers
+   announce new alerts on refresh. */
+
+function renderRedFlagBanner(alerts) {
+    const banner = document.getElementById('red-flag-banner');
+    if (!banner) return;
+    if (!Array.isArray(alerts) || alerts.length === 0) {
+        banner.hidden = true;
+        banner.classList.add('is-hidden');
+        banner.innerHTML = '';
+        return;
+    }
+    const esc = window.fireEscapeHtml || ((s) => s);
+    banner.hidden = false;
+    banner.classList.remove('is-hidden');
+    banner.innerHTML = alerts.map(a => {
+        const expires = a.expires ? new Date(a.expires).toLocaleString() : 'TBD';
+        const headline = a.headline || a.event || 'Fire-weather alert';
+        return `
+            <article class="red-flag-card" data-event="${esc(a.event)}">
+                <header class="red-flag-card-head">
+                    <i class="fas fa-fire-flame-curved" aria-hidden="true"></i>
+                    <strong>${esc(a.event)}</strong>
+                    <span class="red-flag-area">${esc(a.areaDesc)}</span>
+                    <span class="red-flag-expires">until ${esc(expires)}</span>
+                </header>
+                <details>
+                    <summary>${esc(headline)}</summary>
+                    <p>${esc(a.description || '')}</p>
+                    ${a.instruction ? `<p class="red-flag-instruction"><strong>Action:</strong> ${esc(a.instruction)}</p>` : ''}
+                </details>
+            </article>
+        `;
+    }).join('');
+}
+
+window.renderRedFlagBanner = renderRedFlagBanner;

--- a/public/js/fire/FireDataCache.js
+++ b/public/js/fire/FireDataCache.js
@@ -1,0 +1,27 @@
+/* Small client-side cache for the fire-weather snapshot. 60-second TTL,
+   used to avoid re-fetching when the user toggles map layers or revisits
+   tabs within a short window. */
+
+class FireDataCache {
+    constructor(ttlMs = 60 * 1000) {
+        this.ttlMs = ttlMs;
+        this.snapshot = null;
+        this.ts = 0;
+    }
+    isValid() {
+        return this.snapshot && (Date.now() - this.ts) < this.ttlMs;
+    }
+    set(snapshot) {
+        this.snapshot = snapshot;
+        this.ts = Date.now();
+    }
+    get() {
+        return this.isValid() ? this.snapshot : null;
+    }
+    clear() {
+        this.snapshot = null;
+        this.ts = 0;
+    }
+}
+
+window.FireDataCache = FireDataCache;

--- a/public/js/fire/FireListPanel.js
+++ b/public/js/fire/FireListPanel.js
@@ -1,0 +1,111 @@
+/* Auto-generated fire info cards. Renders two sub-sections — Active and
+   Recent — each populated from the server-clustered FIRMS data. Hides
+   the whole panel when both lists are empty. Every metadata field is
+   conditionally rendered so missing values just don't appear. */
+
+function renderFireList(fires) {
+    const panel = document.getElementById('fire-list-panel');
+    const activeList = document.getElementById('active-fires-list');
+    const recentList = document.getElementById('recent-fires-list');
+    const activeGroup = document.getElementById('active-fires-group');
+    const recentGroup = document.getElementById('recent-fires-group');
+    const activeCount = document.getElementById('active-fires-count');
+    const recentCount = document.getElementById('recent-fires-count');
+    if (!panel || !activeList || !recentList) return;
+
+    const active = Array.isArray(fires?.active) ? fires.active : [];
+    const recent = Array.isArray(fires?.recent) ? fires.recent : [];
+
+    if (active.length === 0 && recent.length === 0) {
+        panel.hidden = true;
+        activeList.innerHTML = '';
+        recentList.innerHTML = '';
+        return;
+    }
+    panel.hidden = false;
+
+    if (activeCount) activeCount.textContent = active.length || '0';
+    if (recentCount) recentCount.textContent = recent.length || '0';
+
+    if (activeGroup) activeGroup.hidden = active.length === 0;
+    if (recentGroup) recentGroup.hidden = recent.length === 0;
+
+    activeList.innerHTML = active.map(renderCard).join('');
+    recentList.innerHTML = recent.map(renderCard).join('');
+}
+
+function renderCard(f) {
+    const esc = window.fireEscapeHtml || ((s) => s);
+    const rel = window.formatFireRelativeTime || ((s) => s || '—');
+
+    const title = `Fire near ${f.centerLat.toFixed(3)}, ${f.centerLon.toFixed(3)}`;
+    const confLabel = ({ h: 'high', n: 'nominal', l: 'low' })[f.maxConfidence];
+
+    const rows = [
+        rowIf('Detections',
+            f.detectionCount != null
+                ? `${f.detectionCount} &middot; ~${(f.estimatedAreaKm2 ?? 0).toFixed(2)} km<sup>2</sup>`
+                : null),
+        rowIf('First seen',
+            f.firstSeenAt
+                ? `${esc(rel(f.firstSeenAt))} <span class="fire-card-abs" title="${esc(f.firstSeenAt)}">(${esc(formatAbs(f.firstSeenAt))})</span>`
+                : null),
+        rowIf('Last seen',
+            f.lastSeenAt
+                ? `${esc(rel(f.lastSeenAt))} <span class="fire-card-abs" title="${esc(f.lastSeenAt)}">(${esc(formatAbs(f.lastSeenAt))})</span>`
+                : null),
+        rowIf('Max FRP',
+            f.maxFrp != null ? `${f.maxFrp.toFixed(1)} MW` : null),
+        rowIf('Confidence',
+            confLabel ? esc(confLabel) : null),
+        rowIf('Source',
+            Array.isArray(f.satellites) && f.satellites.length
+                ? esc(f.satellites.join(', ')) : null)
+    ].filter(Boolean).join('');
+
+    const linkAttrs = `data-lat="${f.centerLat}" data-lon="${f.centerLon}"`;
+
+    return `
+        <article class="fire-card" data-fire-id="${esc(f.id)}">
+            <header class="fire-card-head">
+                <h4 class="fire-card-title">${esc(title)}</h4>
+                <span class="fire-status-pill" data-status="${esc(f.status || '')}">${esc(f.status || '')}</span>
+            </header>
+            <dl class="fire-card-meta">${rows}</dl>
+            <p class="fire-card-foot"><a class="fire-card-link" href="#fire-map" ${linkAttrs}>Show on map &rarr;</a></p>
+        </article>
+    `;
+}
+
+function rowIf(label, valueHtml) {
+    if (valueHtml == null) return null;
+    return `<dt>${label}</dt><dd>${valueHtml}</dd>`;
+}
+
+function formatAbs(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleString(undefined, {
+        month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit'
+    });
+}
+
+// Click handler: zoom map to the clicked fire's centroid.
+document.addEventListener('click', (e) => {
+    const link = e.target.closest?.('.fire-card-link');
+    if (!link) return;
+    const lat = parseFloat(link.dataset.lat);
+    const lon = parseFloat(link.dataset.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+    if (window.fireMap && window.fireMap.map) {
+        e.preventDefault();
+        window.fireMap.map.flyTo([lat, lon], 12, { duration: 0.6 });
+        // Keep #fire-map jumping behaviour for non-JS-map fallback users too:
+        const mapEl = document.getElementById('fire-map');
+        if (mapEl) mapEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+});
+
+window.renderFireList = renderFireList;

--- a/public/js/fire/FireWeatherMap.js
+++ b/public/js/fire/FireWeatherMap.js
@@ -1,0 +1,103 @@
+/* Leaflet map of fire-weather stations + FIRMS hotspots. */
+
+class FireWeatherMap {
+    constructor(elId, opts = {}) {
+        this.elId = elId;
+        this.center = opts.center || [40.3033, -109.7];
+        this.zoom = opts.zoom || 9;
+        this.map = null;
+        this.stationMarkers = new Map();
+        this.hotspotMarkers = new Map();
+    }
+
+    init() {
+        const el = document.getElementById(this.elId);
+        if (!el) {
+            console.warn(`FireWeatherMap: element #${this.elId} not found`);
+            return this;
+        }
+        if (typeof L === 'undefined') {
+            console.warn('FireWeatherMap: Leaflet not loaded');
+            return this;
+        }
+        this.map = L.map(el, { scrollWheelZoom: false }).setView(this.center, this.zoom);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 15,
+            minZoom: 6,
+            attribution: '© OpenStreetMap | Wx: NWS, Open-Meteo, Synoptic | Detections: NASA FIRMS VIIRS NOAA-20 NRT'
+        }).addTo(this.map);
+        this.map.on('click', () => { this.map.scrollWheelZoom.enable(); });
+        this.map.on('mouseout', () => { this.map.scrollWheelZoom.disable(); });
+        this._addLegend();
+        return this;
+    }
+
+    _addLegend() {
+        if (!this.map) return;
+        const legend = L.control({ position: 'bottomright' });
+        legend.onAdd = () => {
+            const div = L.DomUtil.create('div', 'fire-map-legend');
+            const swatches = (window.HDW_CLASSES || []).map(c =>
+                `<div class="legend-row"><span class="legend-swatch" style="background:${c.color}"></span>${c.label}</div>`
+            ).join('');
+            div.innerHTML = `
+                <strong>HDW level</strong>
+                ${swatches}
+                <div class="legend-row legend-row-firms"><span class="legend-swatch legend-firms-swatch"></span>FIRMS detection</div>
+            `;
+            return div;
+        };
+        legend.addTo(this.map);
+    }
+
+    renderStations(stations) {
+        if (!this.map) return;
+        for (const m of this.stationMarkers.values()) this.map.removeLayer(m);
+        this.stationMarkers.clear();
+        if (!Array.isArray(stations)) return;
+        for (const s of stations) {
+            if (s.lat == null || s.lng == null) continue;
+            const cls = (window.classifyHDW ? window.classifyHDW(s.hdw) : null);
+            const color = cls?.color || '#888';
+            const value = s.hdw != null ? Math.round(s.hdw) : '·';
+            const icon = L.divIcon({
+                className: 'fire-station-marker',
+                html: `<div class="fire-station-pin" style="background:${color}"><span>${value}</span></div>`,
+                iconSize: [34, 34],
+                iconAnchor: [17, 17]
+            });
+            const marker = L.marker([s.lat, s.lng], { icon }).bindPopup(this._stationPopup(s));
+            marker.addTo(this.map);
+            this.stationMarkers.set(s.stid, marker);
+        }
+    }
+
+    _stationPopup(s) {
+        const fmt = (v, unit, digits = 1) => v == null ? '—' : `${v.toFixed(digits)}${unit}`;
+        const obsTime = s.date ? new Date(s.date).toLocaleString() : 'unknown';
+        const cls = (window.classifyHDW ? window.classifyHDW(s.hdw) : null);
+        const levelHtml = cls ? `<span class="popup-badge" style="background:${cls.color}">${cls.label}</span>` : '';
+        return `
+            <div class="fire-popup">
+                <h4>${escapeHtml(s.name || s.stid)}</h4>
+                <p class="popup-meta">${escapeHtml(s.stid)} · ${obsTime}</p>
+                <p class="popup-row"><strong>HDW</strong> ${fmt(s.hdw, '', 1)} ${levelHtml}</p>
+                <p class="popup-row"><strong>Temp</strong> ${fmt(s.tempC, ' °C')} &nbsp; <strong>RH</strong> ${fmt(s.rh, ' %', 0)}</p>
+                <p class="popup-row"><strong>Wind</strong> ${fmt(s.windMs, ' m/s')}</p>
+            </div>
+        `;
+    }
+}
+
+function escapeHtml(s) {
+    if (s == null) return '';
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+window.FireWeatherMap = FireWeatherMap;
+window.fireEscapeHtml = escapeHtml;

--- a/public/js/fire/HDWClassifier.js
+++ b/public/js/fire/HDWClassifier.js
@@ -1,0 +1,24 @@
+/* Hot-Dry-Windy Index classifier. Thresholds must match the backend
+   (server/fireWeatherService.js HDW_THRESHOLDS). Single source of truth
+   for colors used in HDW badge + map pins. */
+
+const HDW_CLASSES = [
+    { level: 'low',       max: 5,        label: 'Low',       color: '#2d6b3a' },
+    { level: 'moderate',  max: 15,       label: 'Moderate',  color: '#b08600' },
+    { level: 'high',      max: 30,       label: 'High',      color: '#b85a00' },
+    { level: 'very_high', max: 50,       label: 'Very High', color: '#a82632' },
+    { level: 'extreme',   max: Infinity, label: 'Extreme',   color: '#5a0000' }
+];
+
+function classifyHDW(hdw) {
+    if (hdw == null || !Number.isFinite(hdw)) return null;
+    return HDW_CLASSES.find(c => hdw < c.max) || HDW_CLASSES[HDW_CLASSES.length - 1];
+}
+
+function levelMeta(level) {
+    return HDW_CLASSES.find(c => c.level === level) || null;
+}
+
+window.HDW_CLASSES = HDW_CLASSES;
+window.classifyHDW = classifyHDW;
+window.levelMeta = levelMeta;

--- a/public/js/fire/HotspotLayer.js
+++ b/public/js/fire/HotspotLayer.js
@@ -1,0 +1,140 @@
+/* FIRMS satellite hotspot layer + 24h count utility. */
+
+const FIRMS_CONFIDENCE_COLOR = {
+    l: '#ffcc00',
+    n: '#ff8800',
+    h: '#cc0000'
+};
+
+function hotspotColor(h) {
+    if (!h || !h.confidence) return '#ff5722';
+    return FIRMS_CONFIDENCE_COLOR[h.confidence.toLowerCase?.() || h.confidence] || '#ff5722';
+}
+
+function hotspotRadius(h) {
+    const frp = h && Number.isFinite(h.frp) ? h.frp : 0;
+    const base = 4;
+    const scale = Math.min(12, base + Math.sqrt(Math.max(0, frp)));
+    return scale;
+}
+
+function renderHotspots(map, hotspots, hotspotMarkers) {
+    if (!map || typeof L === 'undefined') return;
+    for (const m of hotspotMarkers.values()) map.removeLayer(m);
+    hotspotMarkers.clear();
+    if (!Array.isArray(hotspots)) return;
+    hotspots.forEach((h, idx) => {
+        if (h.lat == null || h.lon == null) return;
+        const marker = L.circleMarker([h.lat, h.lon], {
+            radius: hotspotRadius(h),
+            fillColor: hotspotColor(h),
+            color: '#660000',
+            weight: 1,
+            fillOpacity: 0.85,
+            className: 'fire-hotspot-marker'
+        }).bindPopup(hotspotPopup(h));
+        marker.addTo(map);
+        hotspotMarkers.set(`${h.acqDate}_${h.acqTime}_${idx}`, marker);
+    });
+}
+
+function hotspotPopup(h) {
+    const esc = window.fireEscapeHtml || ((s) => s);
+    const acq = h.acqDate && h.acqTime
+        ? `${h.acqDate} ${h.acqTime.slice(0, 2)}:${h.acqTime.slice(2)} UTC`
+        : 'unknown';
+    const conf = ({ l: 'low', n: 'nominal', h: 'high' })[h.confidence] || h.confidence || '—';
+    const frp = h.frp != null ? `${h.frp.toFixed(1)} MW` : '—';
+    return `
+        <div class="fire-popup">
+            <h4>FIRMS detection</h4>
+            <p class="popup-meta">${esc(h.satellite || 'VIIRS')} · ${esc(acq)}</p>
+            <p class="popup-row"><strong>Confidence</strong> ${esc(conf)}</p>
+            <p class="popup-row"><strong>Fire radiative power</strong> ${esc(frp)}</p>
+            <p class="popup-row"><strong>Location</strong> ${h.lat.toFixed(4)}, ${h.lon.toFixed(4)}</p>
+        </div>
+    `;
+}
+
+function countHotspotsLast24h(hotspots) {
+    if (!Array.isArray(hotspots)) return 0;
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    let n = 0;
+    for (const h of hotspots) {
+        if (!h.acqDate) continue;
+        const time = h.acqTime ? `${h.acqTime.slice(0, 2)}:${h.acqTime.slice(2)}:00Z` : '00:00:00Z';
+        const ts = Date.parse(`${h.acqDate}T${time}`);
+        if (Number.isFinite(ts) && ts >= cutoff) n++;
+    }
+    return n;
+}
+
+/* Fire-cluster overlays — one translucent red circle per confirmed fire,
+   sized to the cluster radius. Drawn beneath the individual hotspot dots
+   so the granular detections stay visible. */
+function renderFires(map, fires, fireLayers) {
+    if (!map || typeof L === 'undefined') return;
+    if (!fireLayers) return;
+    for (const layer of fireLayers.values()) map.removeLayer(layer);
+    fireLayers.clear();
+    if (!Array.isArray(fires)) return;
+
+    for (const f of fires) {
+        if (!Number.isFinite(f.centerLat) || !Number.isFinite(f.centerLon)) continue;
+        const isActive = f.status === 'active';
+        const stroke = isActive ? '#dc2626' : '#8a4a3a';
+        const fill   = isActive ? '#dc2626' : '#a07060';
+        const layer = L.circle([f.centerLat, f.centerLon], {
+            radius: Math.max(f.radiusM || 0, 800),
+            color: stroke,
+            weight: 2,
+            opacity: 0.9,
+            fillColor: fill,
+            fillOpacity: isActive ? 0.18 : 0.10,
+            className: 'fire-cluster-circle'
+        }).bindPopup(firePopupHtml(f));
+        layer.addTo(map);
+        fireLayers.set(f.id, layer);
+    }
+}
+
+function firePopupHtml(f) {
+    const esc = window.fireEscapeHtml || ((s) => s);
+    const confLabel = ({ h: 'high', n: 'nominal', l: 'low' })[f.maxConfidence] || '—';
+    const firstSeen = formatRelativeTime(f.firstSeenAt);
+    const lastSeen = formatRelativeTime(f.lastSeenAt);
+    const frpLine = f.maxFrp != null ? `<p class="popup-row"><strong>Max FRP</strong> ${f.maxFrp.toFixed(1)} MW</p>` : '';
+    const sat = Array.isArray(f.satellites) && f.satellites.length
+        ? `<p class="popup-row"><strong>Source</strong> ${esc(f.satellites.join(', '))}</p>` : '';
+    return `
+        <div class="fire-popup">
+            <h4>Fire near ${f.centerLat.toFixed(3)}, ${f.centerLon.toFixed(3)}</h4>
+            <p class="popup-meta">${f.detectionCount} detection${f.detectionCount === 1 ? '' : 's'} &middot; ~${(f.estimatedAreaKm2 ?? 0).toFixed(2)} km<sup>2</sup></p>
+            <p class="popup-row"><strong>First seen</strong> ${esc(firstSeen)}</p>
+            <p class="popup-row"><strong>Last seen</strong> ${esc(lastSeen)}</p>
+            ${frpLine}
+            <p class="popup-row"><strong>Confidence</strong> ${esc(confLabel)}</p>
+            ${sat}
+            <p class="popup-row"><strong>Status</strong> <span class="popup-badge" style="color:${f.status === 'active' ? '#dc2626' : '#666'}">${esc(f.status || 'unknown')}</span></p>
+        </div>
+    `;
+}
+
+function formatRelativeTime(iso) {
+    if (!iso) return '—';
+    const ts = Date.parse(iso);
+    if (!Number.isFinite(ts)) return '—';
+    const seconds = Math.round((Date.now() - ts) / 1000);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 48) return `${hours}h ago`;
+    const days = Math.round(hours / 24);
+    return `${days}d ago`;
+}
+
+window.renderHotspots = renderHotspots;
+window.renderFires = renderFires;
+window.countHotspotsLast24h = countHotspotsLast24h;
+window.formatFireRelativeTime = formatRelativeTime;

--- a/public/js/fire/Meteogram.js
+++ b/public/js/fire/Meteogram.js
@@ -1,0 +1,36 @@
+/* Open-Meteo 48-hour meteogram (temperature, RH, wind, gusts). */
+
+function renderMeteogram(hourly) {
+    const el = document.getElementById('meteogram');
+    if (!el) return;
+    if (!hourly || !window.Plotly) {
+        el.innerHTML = '<div class="loading-spinner"><i class="fas fa-spinner fa-spin" aria-hidden="true"></i><span>Hourly data unavailable.</span></div>';
+        return;
+    }
+    const t = hourly.time || [];
+    if (t.length === 0) {
+        el.innerHTML = '<div class="loading-spinner"><span>No hourly data returned.</span></div>';
+        return;
+    }
+    const traces = [
+        { x: t, y: hourly.temperature_2m, name: 'Temp (°C)', type: 'scatter', mode: 'lines', line: { color: '#b22222', width: 2 }, yaxis: 'y' },
+        { x: t, y: hourly.relative_humidity_2m, name: 'RH (%)', type: 'scatter', mode: 'lines', line: { color: '#2e8b57', width: 2 }, yaxis: 'y2' },
+        { x: t, y: hourly.wind_speed_10m, name: 'Wind (m/s)', type: 'scatter', mode: 'lines', line: { color: '#ff8c00', width: 2 }, yaxis: 'y3' },
+        { x: t, y: hourly.wind_gusts_10m, name: 'Gusts (m/s)', type: 'scatter', mode: 'lines', line: { color: '#ff4500', width: 2, dash: 'dot' }, yaxis: 'y3' }
+    ];
+    const layout = {
+        margin: { l: 55, r: 70, t: 25, b: 45 },
+        plot_bgcolor: '#fff8f0',
+        paper_bgcolor: '#fff',
+        xaxis: { title: '', tickfont: { size: 11 } },
+        yaxis: { title: 'Temp °C', side: 'left', titlefont: { color: '#b22222' }, tickfont: { color: '#b22222' } },
+        yaxis2: { title: 'RH %', overlaying: 'y', side: 'right', titlefont: { color: '#2e8b57' }, tickfont: { color: '#2e8b57' } },
+        yaxis3: { title: 'm/s', overlaying: 'y', side: 'right', anchor: 'free', position: 1.0, showgrid: false, titlefont: { color: '#ff8c00' }, tickfont: { color: '#ff8c00' } },
+        legend: { orientation: 'h', y: -0.2, x: 0 },
+        showlegend: true,
+        hovermode: 'x unified'
+    };
+    Plotly.newPlot('meteogram', traces, layout, { displayModeBar: false, responsive: true });
+}
+
+window.renderMeteogram = renderMeteogram;

--- a/public/js/fire/RestrictionsPanel.js
+++ b/public/js/fire/RestrictionsPanel.js
@@ -1,0 +1,76 @@
+/* Active fire-restriction cards for the Uinta Basin. Hides the section
+   when there are no restrictions, renders one card per active order.
+   Summary text + highlights come from the hand-maintained lookup in
+   server/data/fireRestrictionsSummaries.json (keyed by OrderNum). */
+
+function renderRestrictions(restrictions) {
+    const panel = document.getElementById('fire-restrictions-panel');
+    const list = document.getElementById('fire-restrictions-list');
+    if (!panel || !list) return;
+
+    if (!Array.isArray(restrictions) || restrictions.length === 0) {
+        panel.hidden = true;
+        list.innerHTML = '';
+        return;
+    }
+
+    const esc = window.fireEscapeHtml || ((s) => s);
+    panel.hidden = false;
+    list.innerHTML = restrictions.map(r => {
+        const area = r.areaDescription || r.shortArea || 'Unknown area';
+        const type = r.type || 'Restriction';
+        const typeAttr = String(type).toLowerCase().replace(/[^a-z0-9]+/g, '-');
+        const effective = formatDate(r.effectiveAt);
+        const rescinded = formatDate(r.rescindedAt);
+        const dateLine = rescinded
+            ? `Effective ${effective || '—'} → through ${rescinded}`
+            : (effective ? `Effective since ${effective}` : '');
+
+        const body = renderBody(r, esc);
+
+        const order = r.orderNum ? `<span class="restriction-order">Order ${esc(r.orderNum)}</span>` : '';
+        const cta = r.link
+            ? `<a class="restriction-link" href="${esc(r.link)}" target="_blank" rel="noopener noreferrer">Read full order &rarr;</a>`
+            : `<span class="restriction-no-link">Contact the issuing agency for the official text.</span>`;
+
+        return `
+            <article class="restriction-card">
+                <header class="restriction-card-head">
+                    <span class="restriction-agency">${esc(r.agency || 'Issuing agency')}</span>
+                    <span class="restriction-type-pill" data-type="${esc(typeAttr)}">${esc(type)}</span>
+                </header>
+                <p class="restriction-area">${esc(area)}</p>
+                ${body}
+                ${dateLine ? `<p class="restriction-meta">${esc(dateLine)}</p>` : ''}
+                <div class="restriction-foot">${order}${cta}</div>
+            </article>
+        `;
+    }).join('');
+}
+
+function renderBody(r, esc) {
+    const hasSummary = typeof r.summary === 'string' && r.summary.trim().length > 0;
+    const hasHighlights = Array.isArray(r.highlights) && r.highlights.length > 0;
+
+    if (!hasSummary && !hasHighlights) {
+        return `<p class="restriction-empty">No summary written yet &mdash; read the full order for prohibited activities.</p>`;
+    }
+
+    const heading = `<h3 class="restriction-summary-heading">What this order prohibits</h3>`;
+    const summary = hasSummary
+        ? `<p class="restriction-summary">${esc(r.summary)}</p>`
+        : '';
+    const highlights = hasHighlights
+        ? `<ul class="restriction-highlights">${r.highlights.map(h => `<li>${esc(h)}</li>`).join('')}</ul>`
+        : '';
+    return heading + summary + highlights;
+}
+
+function formatDate(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+window.renderRestrictions = renderRestrictions;

--- a/public/js/fire/initialization.js
+++ b/public/js/fire/initialization.js
@@ -1,0 +1,179 @@
+/* Fire-weather page orchestrator. Fetches /api/fire-weather every 5 min,
+   /api/fire-weather/alerts every 2 min (lighter), renders into the
+   pre-existing markup. */
+
+let fireMap = null;
+let fireDataCache = null;
+let snapshotInterval = null;
+let consecutiveFailures = 0;
+
+const REFRESH_FULL_MS = 5 * 60 * 1000;
+const REFRESH_ALERTS_MS = 2 * 60 * 1000;
+const REFRESH_RESTRICTIONS_MS = 30 * 60 * 1000;
+const RETRY_FAST_MS = 15 * 1000;
+
+document.addEventListener('DOMContentLoaded', () => {
+    fireDataCache = new FireDataCache();
+    fireMap = new FireWeatherMap('fire-map').init();
+    if (fireMap) fireMap.fireLayers = new Map();
+    window.fireMap = fireMap;
+
+    loadFullSnapshot();
+    loadRestrictions();
+    snapshotInterval = setInterval(loadFullSnapshot, REFRESH_FULL_MS);
+    setInterval(loadAlertsOnly, REFRESH_ALERTS_MS);
+    setInterval(loadRestrictions, REFRESH_RESTRICTIONS_MS);
+});
+
+async function loadFullSnapshot() {
+    try {
+        const r = await fetch('/api/fire-weather');
+        if (!r.ok) throw new Error(`/api/fire-weather ${r.status}`);
+        const data = await r.json();
+        fireDataCache.set(data);
+        consecutiveFailures = 0;
+        renderAll(data);
+    } catch (err) {
+        consecutiveFailures += 1;
+        console.warn(`fire-weather fetch attempt ${consecutiveFailures} failed:`, err.message);
+        if (consecutiveFailures >= 3) {
+            markLoadFailure();
+        }
+        // fast retry: schedule a single quick re-attempt; the 5-min interval
+        // continues independently.
+        setTimeout(() => {
+            if (consecutiveFailures > 0) loadFullSnapshot();
+        }, RETRY_FAST_MS);
+    }
+}
+
+async function loadAlertsOnly() {
+    try {
+        const r = await fetch('/api/fire-weather/alerts');
+        if (!r.ok) return;
+        const data = await r.json();
+        renderRedFlagBanner(data.alerts || []);
+    } catch (err) {
+        console.warn('Alerts refresh failed:', err);
+    }
+}
+
+async function loadRestrictions() {
+    try {
+        const r = await fetch('/api/fire-restrictions');
+        if (!r.ok) return;
+        const data = await r.json();
+        if (typeof window.renderRestrictions === 'function') {
+            window.renderRestrictions(data.restrictions || []);
+        }
+    } catch (err) {
+        console.warn('Fire restrictions refresh failed:', err);
+    }
+}
+
+function renderAll(data) {
+    renderRedFlagBanner(data.alerts || []);
+    renderHero(data.basin, data.stationMax, data.hotspots || []);
+    renderCards(data.basin, data.stationMax);
+    if (fireMap) {
+        fireMap.renderStations(data.stations || []);
+        renderHotspots(fireMap.map, data.hotspots || [], fireMap.hotspotMarkers);
+        const fires = data.fires || { active: [], recent: [] };
+        const allFires = [...(fires.active || []), ...(fires.recent || [])];
+        if (typeof window.renderFires === 'function') {
+            window.renderFires(fireMap.map, allFires, fireMap.fireLayers || new Map());
+        }
+    }
+    if (typeof window.renderFireList === 'function') {
+        window.renderFireList(data.fires || { active: [], recent: [] });
+    }
+    renderForecastStrip(data.forecast || []);
+    renderMeteogram(data.hourly);
+}
+
+function renderHero(basin, stationMax, hotspots) {
+    const badge = document.getElementById('basin-hdw-badge');
+    const valueEl = document.getElementById('basin-hdw-value');
+    const levelEl = document.getElementById('basin-hdw-level-name');
+    const sourceEl = document.getElementById('basin-hdw-source');
+    const snapshotEl = document.getElementById('hero-snapshot');
+    const chip = document.getElementById('hotspot-count-chip');
+    const chipValue = document.getElementById('hotspot-count-value');
+
+    if (basin && basin.hdw != null) {
+        const cls = classifyHDW(basin.hdw);
+        if (badge) badge.setAttribute('data-level', cls?.level || 'low');
+        if (valueEl) valueEl.textContent = basin.hdw.toFixed(1);
+        if (levelEl) levelEl.textContent = cls?.label || '—';
+        if (sourceEl) sourceEl.textContent = basin.hdwSource ? `peak: ${basin.hdwSource}` : '';
+    } else {
+        if (badge) badge.setAttribute('data-level', 'low');
+        if (valueEl) valueEl.textContent = '—';
+        if (levelEl) levelEl.textContent = 'No data';
+        if (sourceEl) sourceEl.textContent = '';
+    }
+
+    if (snapshotEl) {
+        const parts = [];
+        if (basin?.tempC != null) parts.push(`${basin.tempC.toFixed(1)} °C`);
+        if (basin?.rhPercent != null) parts.push(`${Math.round(basin.rhPercent)}% RH`);
+        if (basin?.windMs != null) parts.push(`wind ${basin.windMs.toFixed(1)} m/s`);
+        if (basin?.gustMs != null) parts.push(`gust ${basin.gustMs.toFixed(1)} m/s`);
+        snapshotEl.textContent = parts.length ? parts.join(' · ') : 'Basin centroid conditions unavailable.';
+    }
+
+    const count = countHotspotsLast24h(hotspots);
+    if (chip && chipValue) {
+        if (count > 0) {
+            chipValue.textContent = count;
+            chip.hidden = false;
+            chip.classList.remove('is-hidden');
+        } else {
+            chip.hidden = true;
+            chip.classList.add('is-hidden');
+        }
+    }
+}
+
+function renderCards(basin, stationMax) {
+    setText('card-temp', basin?.tempC != null ? `${basin.tempC.toFixed(1)} °C` : '—');
+    setText('card-rh', basin?.rhPercent != null ? `${Math.round(basin.rhPercent)} %` : '—');
+    setText('card-wind', basin?.windMs != null ? `${basin.windMs.toFixed(1)} m/s` : '—');
+    setText('card-wind-trend', basin?.gustMs != null ? `gust ${basin.gustMs.toFixed(1)} m/s` : 'gust —');
+
+    if (stationMax && stationMax.hdw != null) {
+        setText('card-hdw', stationMax.hdw.toFixed(1));
+        setText('card-hdw-station', stationMax.name || stationMax.stid || '');
+    } else {
+        setText('card-hdw', '—');
+        setText('card-hdw-station', 'no station data');
+    }
+}
+
+function renderForecastStrip(periods) {
+    const strip = document.getElementById('forecast-strip');
+    if (!strip) return;
+    if (!Array.isArray(periods) || periods.length === 0) {
+        strip.innerHTML = '<div class="loading-spinner"><span>NWS forecast unavailable.</span></div>';
+        return;
+    }
+    const esc = window.fireEscapeHtml || ((s) => s);
+    strip.innerHTML = periods.slice(0, 10).map(p => `
+        <article class="forecast-day-card">
+            <h3>${esc(p.name || '')}</h3>
+            <p class="forecast-temp">${p.temperature ?? '—'}°${esc(p.temperatureUnit || 'F')}</p>
+            <p class="forecast-wind">${esc(p.windSpeed || '—')} ${esc(p.windDirection || '')}</p>
+            <p class="forecast-short">${esc(p.shortForecast || '')}</p>
+        </article>
+    `).join('');
+}
+
+function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+}
+
+function markLoadFailure() {
+    const snapshotEl = document.getElementById('hero-snapshot');
+    if (snapshotEl) snapshotEl.textContent = 'Unable to load fire-weather data — retrying.';
+}

--- a/public/js/loadSidebar.js
+++ b/public/js/loadSidebar.js
@@ -22,6 +22,12 @@ const PAGE_DISCLAIMERS = {
         Always check current conditions and weather warnings before water activities.
         ©2025, Utah State University.`,
 
+    '/fire': `DISCLAIMER: Fire-weather products are experimental research outputs and informational only.
+        They are NOT a substitute for official NWS forecasts and must NOT be used for fire-suppression decisions.
+        Satellite hotspot detections (NASA FIRMS) can lag by ~3 hours and may include false positives.
+        For active wildfires and operational guidance, consult Utah Fire Info and the National Weather Service.
+        ©2026, Utah State University.`,
+
     '/locations': `DISCLAIMER: Real-time data are preliminary and have yet to undergo quality control.
         Some data are obtained in cooperation with other agencies, including the Ute Indian Tribe and the Utah Department of Environmental Quality. ©2025, Utah State University.`,
 

--- a/server/__tests__/fireClustering.test.js
+++ b/server/__tests__/fireClustering.test.js
@@ -1,0 +1,233 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+    clusterDetections,
+    categorizeAndConfirm,
+    haversineMeters,
+    parseDetectionTime,
+    ACTIVE_WINDOW_HOURS,
+    RECENT_WINDOW_HOURS
+} from '../fireClustering.js';
+
+// Helper: build a synthetic FIRMS detection row.
+// dateOffsetHours is hours BEFORE the test "now" (positive = older).
+const NOW_MS = Date.parse('2026-05-28T18:00:00Z');
+
+function det({ lat, lon, hoursAgo = 0, confidence = 'h', frp = 5, satellite = 'N20' }) {
+    const ts = NOW_MS - hoursAgo * 3600 * 1000;
+    const d = new Date(ts);
+    const acqDate = d.toISOString().slice(0, 10);
+    const hh = String(d.getUTCHours()).padStart(2, '0');
+    const mm = String(d.getUTCMinutes()).padStart(2, '0');
+    return {
+        lat,
+        lon,
+        confidence,
+        frp,
+        satellite,
+        acqDate,
+        acqTime: `${hh}${mm}`
+    };
+}
+
+describe('haversineMeters', () => {
+    it('returns ~0 for same point', () => {
+        expect(haversineMeters(40, -110, 40, -110)).toBeLessThan(1);
+    });
+
+    it('approximates a known short distance (~157km between two basin points)', () => {
+        // 1° latitude ≈ 111 km
+        const d = haversineMeters(40.0, -110.0, 41.0, -110.0);
+        expect(d).toBeGreaterThan(110_000);
+        expect(d).toBeLessThan(112_000);
+    });
+});
+
+describe('parseDetectionTime', () => {
+    it('parses acqDate + acqTime correctly as UTC ms', () => {
+        const t = parseDetectionTime({ acqDate: '2026-05-28', acqTime: '0841' });
+        expect(t).toBe(Date.parse('2026-05-28T08:41:00Z'));
+    });
+
+    it('zero-pads short acqTime', () => {
+        const t = parseDetectionTime({ acqDate: '2026-05-28', acqTime: '841' });
+        expect(t).toBe(Date.parse('2026-05-28T08:41:00Z'));
+    });
+
+    it('returns null on missing date', () => {
+        expect(parseDetectionTime({ acqTime: '0900' })).toBeNull();
+        expect(parseDetectionTime(null)).toBeNull();
+    });
+});
+
+describe('clusterDetections', () => {
+    it('groups two detections within 500m into one cluster', () => {
+        const a = det({ lat: 40.1240, lon: -110.3717, hoursAgo: 2 });
+        const b = det({ lat: 40.1245, lon: -110.3720, hoursAgo: 1 });
+        const clusters = clusterDetections([a, b]);
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].detectionCount).toBe(2);
+    });
+
+    it('keeps two detections >5km apart in separate clusters', () => {
+        const a = det({ lat: 40.10, lon: -110.10, hoursAgo: 2 });
+        const b = det({ lat: 40.20, lon: -110.10, hoursAgo: 2 }); // ~11km north
+        const clusters = clusterDetections([a, b]);
+        expect(clusters).toHaveLength(2);
+    });
+
+    it('produces stable ids across reruns (idempotent)', () => {
+        const inputs = [
+            det({ lat: 40.124, lon: -110.371, hoursAgo: 2 }),
+            det({ lat: 40.125, lon: -110.372, hoursAgo: 1 })
+        ];
+        const first = clusterDetections(inputs);
+        const second = clusterDetections(inputs);
+        expect(first.map(f => f.id)).toEqual(second.map(f => f.id));
+    });
+
+    it('ignores detections with missing lat/lon', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.12, lon: -110.37, hoursAgo: 2 }),
+            { lat: null, lon: null, acqDate: '2026-05-28', acqTime: '0900' },
+            {}
+        ]);
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].detectionCount).toBe(1);
+    });
+
+    it('accumulates max/mean FRP and worst-case confidence', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.12, lon: -110.37, hoursAgo: 2, frp: 5, confidence: 'l' }),
+            det({ lat: 40.121, lon: -110.371, hoursAgo: 1, frp: 20, confidence: 'h' })
+        ]);
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].maxFrp).toBe(20);
+        expect(clusters[0].meanFrp).toBeCloseTo(12.5, 1);
+        expect(clusters[0].maxConfidence).toBe('h');
+    });
+
+    it('reports estimatedAreaKm2 ~ detection count × VIIRS pixel area', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.12, lon: -110.37, hoursAgo: 2 }),
+            det({ lat: 40.121, lon: -110.371, hoursAgo: 1 }),
+            det({ lat: 40.1205, lon: -110.3705, hoursAgo: 1 })
+        ]);
+        expect(clusters[0].estimatedAreaKm2).toBeCloseTo(0.42, 2);
+    });
+
+    it('handles empty / non-array input gracefully', () => {
+        expect(clusterDetections([])).toEqual([]);
+        expect(clusterDetections(null)).toEqual([]);
+        expect(clusterDetections(undefined)).toEqual([]);
+    });
+});
+
+describe('confirmation', () => {
+    it('confirms a single high-confidence detection', () => {
+        const [c] = clusterDetections([det({ lat: 40.1, lon: -110.1, confidence: 'h' })]);
+        expect(c.confirmed).toBe(true);
+    });
+
+    it('does not confirm a single low-confidence detection', () => {
+        const [c] = clusterDetections([det({ lat: 40.1, lon: -110.1, confidence: 'l' })]);
+        expect(c.confirmed).toBe(false);
+    });
+
+    it('confirms two low-confidence detections (count threshold)', () => {
+        const [c] = clusterDetections([
+            det({ lat: 40.1, lon: -110.1, hoursAgo: 2, confidence: 'l' }),
+            det({ lat: 40.1005, lon: -110.1005, hoursAgo: 1, confidence: 'l' })
+        ]);
+        expect(c.confirmed).toBe(true);
+        expect(c.detectionCount).toBe(2);
+    });
+});
+
+describe('categorizeAndConfirm', () => {
+    it('puts a 2h-ago confirmed cluster in active', () => {
+        const clusters = clusterDetections([det({ lat: 40.1, lon: -110.1, hoursAgo: 2 })]);
+        const { active, recent } = categorizeAndConfirm(clusters, NOW_MS);
+        expect(active).toHaveLength(1);
+        expect(recent).toHaveLength(0);
+        expect(active[0].status).toBe('active');
+    });
+
+    it('puts a 30h-ago confirmed cluster in recent', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.1, lon: -110.1, hoursAgo: 32 }),
+            det({ lat: 40.1005, lon: -110.1005, hoursAgo: 30 })
+        ]);
+        const { active, recent } = categorizeAndConfirm(clusters, NOW_MS);
+        expect(active).toHaveLength(0);
+        expect(recent).toHaveLength(1);
+        expect(recent[0].status).toBe('recent');
+    });
+
+    it('drops a cluster older than the recent window', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.1, lon: -110.1, hoursAgo: 80, confidence: 'h' })
+        ]);
+        const { active, recent } = categorizeAndConfirm(clusters, NOW_MS);
+        expect(active).toHaveLength(0);
+        expect(recent).toHaveLength(0);
+    });
+
+    it('drops unconfirmed clusters even when timing is fine', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.1, lon: -110.1, hoursAgo: 2, confidence: 'l' })
+        ]);
+        const { active, recent } = categorizeAndConfirm(clusters, NOW_MS);
+        expect(active).toHaveLength(0);
+        expect(recent).toHaveLength(0);
+    });
+
+    it('sorts active and recent by lastSeenAt descending', () => {
+        const clusters = clusterDetections([
+            // older active
+            det({ lat: 40.20, lon: -110.20, hoursAgo: 10 }),
+            // newer active (different cluster)
+            det({ lat: 40.10, lon: -110.10, hoursAgo: 2 }),
+            // recent
+            det({ lat: 40.30, lon: -110.30, hoursAgo: 30 }),
+            det({ lat: 40.3005, lon: -110.3005, hoursAgo: 28 })
+        ]);
+        const { active, recent } = categorizeAndConfirm(clusters, NOW_MS);
+        expect(active).toHaveLength(2);
+        const aT0 = Date.parse(active[0].lastSeenAt);
+        const aT1 = Date.parse(active[1].lastSeenAt);
+        expect(aT0).toBeGreaterThan(aT1);
+        expect(recent).toHaveLength(1);
+    });
+
+    it('boundary: lastSeenAt exactly at ACTIVE_WINDOW_HOURS is still active', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.1, lon: -110.1, hoursAgo: ACTIVE_WINDOW_HOURS, confidence: 'h' })
+        ]);
+        const { active, recent } = categorizeAndConfirm(clusters, NOW_MS);
+        expect(active).toHaveLength(1);
+        expect(recent).toHaveLength(0);
+    });
+
+    it('boundary: just past ACTIVE_WINDOW_HOURS moves to recent', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.1, lon: -110.1, hoursAgo: ACTIVE_WINDOW_HOURS + 1, confidence: 'h' })
+        ]);
+        const { active, recent } = categorizeAndConfirm(clusters, NOW_MS);
+        expect(active).toHaveLength(0);
+        expect(recent).toHaveLength(1);
+    });
+
+    it('boundary: past RECENT_WINDOW_HOURS is dropped', () => {
+        const clusters = clusterDetections([
+            det({ lat: 40.1, lon: -110.1, hoursAgo: RECENT_WINDOW_HOURS + 1, confidence: 'h' })
+        ]);
+        const { active, recent } = categorizeAndConfirm(clusters, NOW_MS);
+        expect(active).toHaveLength(0);
+        expect(recent).toHaveLength(0);
+    });
+
+    it('handles empty/non-array input gracefully', () => {
+        expect(categorizeAndConfirm([], NOW_MS)).toEqual({ active: [], recent: [] });
+        expect(categorizeAndConfirm(null, NOW_MS)).toEqual({ active: [], recent: [] });
+    });
+});

--- a/server/fireClustering.js
+++ b/server/fireClustering.js
@@ -1,0 +1,236 @@
+/* Pure functions for clustering NASA FIRMS hotspot detections into fire
+   entities and categorizing them by status (active / recent).
+   No I/O, no network — all inputs come in as plain JS objects.
+   Deterministic given the same inputs (suitable for snapshot tests). */
+
+export const CLUSTER_RADIUS_M = 1500;           // detections within this distance merge into one fire
+export const VIIRS_PIXEL_BUFFER_M = 500;        // half a VIIRS pixel; padding added to cluster radius
+export const VIIRS_PIXEL_AREA_KM2 = 0.14;       // ~ 375m × 375m
+export const ACTIVE_WINDOW_HOURS = 12;
+export const RECENT_WINDOW_HOURS = 72;
+
+const EARTH_RADIUS_M = 6_371_000;
+
+function toRad(deg) { return (deg * Math.PI) / 180; }
+
+export function haversineMeters(lat1, lon1, lat2, lon2) {
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a = Math.sin(dLat / 2) ** 2
+        + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    return EARTH_RADIUS_M * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/** FIRMS gives `acqDate` "YYYY-MM-DD" and `acqTime` "HHMM" (UTC). Returns ms since epoch, or null. */
+export function parseDetectionTime(d) {
+    if (!d || !d.acqDate) return null;
+    const raw = d.acqTime != null ? String(d.acqTime) : '0000';
+    const padded = raw.padStart(4, '0');
+    const hh = padded.slice(0, 2);
+    const mm = padded.slice(2, 4);
+    const ts = Date.parse(`${d.acqDate}T${hh}:${mm}:00Z`);
+    return Number.isFinite(ts) ? ts : null;
+}
+
+function normalizeConfidence(c) {
+    if (c == null) return null;
+    const s = String(c).toLowerCase();
+    if (s === 'h' || s === 'high') return 'h';
+    if (s === 'n' || s === 'nominal') return 'n';
+    if (s === 'l' || s === 'low') return 'l';
+    return null;
+}
+
+const CONFIDENCE_RANK = { l: 0, n: 1, h: 2 };
+
+function compareConfidence(a, b) {
+    return (CONFIDENCE_RANK[a] ?? -1) - (CONFIDENCE_RANK[b] ?? -1);
+}
+
+/**
+ * Cluster detections by spatial proximity using a greedy nearest-cluster
+ * pass. Sorted by time first so the result is deterministic for the same
+ * input set.
+ *
+ * @param {Array} detections - raw FIRMS rows
+ * @param {Object} [opts]
+ * @returns {Array} fires
+ */
+export function clusterDetections(detections, opts = {}) {
+    const clusterRadius = opts.clusterRadiusM ?? CLUSTER_RADIUS_M;
+    const pixelBuffer = opts.pixelBufferM ?? VIIRS_PIXEL_BUFFER_M;
+    const pixelArea = opts.pixelAreaKm2 ?? VIIRS_PIXEL_AREA_KM2;
+
+    if (!Array.isArray(detections)) return [];
+
+    const valid = detections.filter(d =>
+        d && Number.isFinite(d.lat) && Number.isFinite(d.lon)
+    );
+
+    // Sort by time (then by lat,lon) so clustering is deterministic.
+    const sorted = [...valid].sort((a, b) => {
+        const aT = parseDetectionTime(a) ?? 0;
+        const bT = parseDetectionTime(b) ?? 0;
+        if (aT !== bT) return aT - bT;
+        if (a.lat !== b.lat) return a.lat - b.lat;
+        return a.lon - b.lon;
+    });
+
+    const clusters = [];
+    for (const d of sorted) {
+        let bestIdx = -1;
+        let bestDist = Infinity;
+        for (let i = 0; i < clusters.length; i++) {
+            const c = clusters[i];
+            const dist = haversineMeters(d.lat, d.lon, c.centerLat, c.centerLon);
+            if (dist <= clusterRadius && dist < bestDist) {
+                bestIdx = i;
+                bestDist = dist;
+            }
+        }
+        if (bestIdx >= 0) {
+            addToCluster(clusters[bestIdx], d);
+        } else {
+            clusters.push(newCluster(d));
+        }
+    }
+
+    return clusters.map(c => finalizeCluster(c, { pixelBuffer, pixelArea }));
+}
+
+function newCluster(d) {
+    return {
+        detections: [d],
+        sumLat: d.lat,
+        sumLon: d.lon,
+        centerLat: d.lat,
+        centerLon: d.lon
+    };
+}
+
+function addToCluster(c, d) {
+    c.detections.push(d);
+    c.sumLat += d.lat;
+    c.sumLon += d.lon;
+    const n = c.detections.length;
+    c.centerLat = c.sumLat / n;
+    c.centerLon = c.sumLon / n;
+}
+
+function finalizeCluster(c, { pixelBuffer, pixelArea }) {
+    const dets = c.detections;
+
+    let north = -Infinity, south = Infinity, east = -Infinity, west = Infinity;
+    let firstSeen = Infinity, lastSeen = -Infinity;
+    let maxFrp = null, sumFrp = 0, frpCount = 0;
+    let maxConfidence = null;
+    let anyNonLow = false;
+    const satellites = new Set();
+    let maxDistFromCentroid = 0;
+
+    for (const d of dets) {
+        north = Math.max(north, d.lat);
+        south = Math.min(south, d.lat);
+        east = Math.max(east, d.lon);
+        west = Math.min(west, d.lon);
+
+        const ts = parseDetectionTime(d);
+        if (ts != null) {
+            if (ts < firstSeen) firstSeen = ts;
+            if (ts > lastSeen) lastSeen = ts;
+        }
+
+        if (Number.isFinite(d.frp)) {
+            maxFrp = maxFrp == null ? d.frp : Math.max(maxFrp, d.frp);
+            sumFrp += d.frp;
+            frpCount += 1;
+        }
+
+        const conf = normalizeConfidence(d.confidence);
+        if (conf) {
+            if (conf !== 'l') anyNonLow = true;
+            if (maxConfidence == null || compareConfidence(conf, maxConfidence) > 0) {
+                maxConfidence = conf;
+            }
+        }
+
+        if (d.satellite) satellites.add(String(d.satellite));
+
+        const dist = haversineMeters(c.centerLat, c.centerLon, d.lat, d.lon);
+        if (dist > maxDistFromCentroid) maxDistFromCentroid = dist;
+    }
+
+    const radiusM = Math.round(maxDistFromCentroid + pixelBuffer);
+    const id = `${c.centerLat.toFixed(3)}_${c.centerLon.toFixed(3)}`;
+    const confirmed = dets.length >= 2 || anyNonLow;
+
+    return {
+        id,
+        centerLat: round(c.centerLat, 5),
+        centerLon: round(c.centerLon, 5),
+        radiusM,
+        bbox: {
+            north: round(north, 5),
+            south: round(south, 5),
+            east: round(east, 5),
+            west: round(west, 5)
+        },
+        detectionCount: dets.length,
+        firstSeenAt: Number.isFinite(firstSeen) ? new Date(firstSeen).toISOString() : null,
+        lastSeenAt: Number.isFinite(lastSeen) ? new Date(lastSeen).toISOString() : null,
+        maxFrp,
+        meanFrp: frpCount > 0 ? round(sumFrp / frpCount, 2) : null,
+        maxConfidence,
+        satellites: [...satellites].sort(),
+        estimatedAreaKm2: round(dets.length * pixelArea, 2),
+        confirmed,
+        status: null,
+        detections: dets
+    };
+}
+
+function round(n, digits) {
+    const m = 10 ** digits;
+    return Math.round(n * m) / m;
+}
+
+/**
+ * Assign status ("active" | "recent") based on lastSeenAt vs nowMs, drop
+ * unconfirmed clusters, drop anything older than the recent window.
+ *
+ * @param {Array} clusters - output of clusterDetections
+ * @param {number} nowMs - reference clock (Date.now() in production, fixed in tests)
+ * @param {Object} [opts]
+ * @returns {{ active: Array, recent: Array }}
+ */
+export function categorizeAndConfirm(clusters, nowMs, opts = {}) {
+    const activeMs = (opts.activeHours ?? ACTIVE_WINDOW_HOURS) * 3600 * 1000;
+    const recentMs = (opts.recentHours ?? RECENT_WINDOW_HOURS) * 3600 * 1000;
+
+    const active = [];
+    const recent = [];
+
+    if (!Array.isArray(clusters)) return { active, recent };
+
+    for (const c of clusters) {
+        if (!c.confirmed) continue;
+        if (!c.lastSeenAt) continue;
+        const lastMs = Date.parse(c.lastSeenAt);
+        if (!Number.isFinite(lastMs)) continue;
+        const age = nowMs - lastMs;
+        if (age < -60 * 1000) continue; // tolerate a tiny clock skew
+        if (age <= activeMs) {
+            active.push({ ...c, status: 'active' });
+        } else if (age <= recentMs) {
+            recent.push({ ...c, status: 'recent' });
+        }
+        // else: silently dropped — outside our retention window
+    }
+
+    const byLastSeenDesc = (a, b) =>
+        Date.parse(b.lastSeenAt) - Date.parse(a.lastSeenAt);
+    active.sort(byLastSeenDesc);
+    recent.sort(byLastSeenDesc);
+
+    return { active, recent };
+}

--- a/server/fireRestrictionsService.js
+++ b/server/fireRestrictionsService.js
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fetch from 'node-fetch';
+import NodeCache from 'node-cache';
+import { UINTA_BASIN_BBOX } from './fireWeatherService.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const cache = new NodeCache({ stdTTL: 30 * 60 });
+
+const ARCGIS_FIRE_RESTRICTIONS_URL =
+    'https://services.arcgis.com/ZzrwjTRez6FJiOq4/arcgis/rest/services/Fire_Restrictions/FeatureServer/0/query';
+
+// Mirror of the Agency coded-value domain on the FeatureLayer. Values are
+// stored as short codes; this maps them to the human-readable name.
+const AGENCY_NAMES = {
+    '1-FFSL': 'Utah FFSL',
+    '2-USFS': 'US Forest Service',
+    '3-BLM': 'Bureau of Land Management',
+    '4-NPS': 'National Park Service',
+    '5-Navajo': 'Navajo Nation',
+    '6-Ute': 'Ute Indian Tribe'
+};
+
+// Hand-written compact summaries keyed by OrderNum. Loaded once at startup;
+// edit the JSON and restart the server to refresh. Missing file or invalid
+// JSON degrades gracefully — cards render the "no summary" fallback.
+const SUMMARIES = loadSummaries();
+
+function loadSummaries() {
+    const summariesPath = path.join(__dirname, 'data', 'fireRestrictionsSummaries.json');
+    try {
+        const raw = fs.readFileSync(summariesPath, 'utf8');
+        const parsed = JSON.parse(raw);
+        delete parsed._meta;
+        return parsed;
+    } catch (err) {
+        console.warn(`fireRestrictionsService: could not load summaries (${err.message}); proceeding without`);
+        return {};
+    }
+}
+
+function isoFromEpochMs(ms) {
+    if (ms == null || !Number.isFinite(ms)) return null;
+    const d = new Date(ms);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function normalizeFeature(feature) {
+    const a = feature?.attributes || {};
+    const agencyCode = a.Agency || null;
+    const orderNum = a.OrderNum || null;
+    const entry = (orderNum && SUMMARIES[orderNum]) || null;
+    return {
+        orderNum,
+        agency: AGENCY_NAMES[agencyCode] || agencyCode,
+        type: a.RestrictionType || null,
+        status: a.Status || null,
+        areaDescription: a.AreaDescription || null,
+        shortArea: a.Short_AreaDescription || null,
+        effectiveAt: isoFromEpochMs(a.EffectiveDate),
+        rescindedAt: isoFromEpochMs(a.RescindedDate),
+        link: a.Link || null,
+        hasCampfire: Number(a.Campfire_etc) === 1,
+        hasFireworks: Number(a.Fireworks) === 1,
+        summary: entry?.summary || null,
+        highlights: Array.isArray(entry?.highlights) ? entry.highlights : null
+    };
+}
+
+class FireRestrictionsService {
+    async fetchActiveRestrictions(bbox = UINTA_BASIN_BBOX) {
+        const cacheKey = `fire_restrictions_${bbox.west}_${bbox.south}_${bbox.east}_${bbox.north}`;
+        const cached = cache.get(cacheKey);
+        if (cached) return cached;
+
+        const geometry = JSON.stringify({
+            xmin: bbox.west,
+            ymin: bbox.south,
+            xmax: bbox.east,
+            ymax: bbox.north,
+            spatialReference: { wkid: 4326 }
+        });
+
+        const params = new URLSearchParams({
+            where: "Status='Active'",
+            geometry,
+            geometryType: 'esriGeometryEnvelope',
+            inSR: '4326',
+            spatialRel: 'esriSpatialRelIntersects',
+            outFields: [
+                'OrderNum', 'Agency', 'EffectiveDate', 'RescindedDate',
+                'AreaDescription', 'Short_AreaDescription', 'Link',
+                'RestrictionType', 'Status', 'Campfire_etc', 'Fireworks'
+            ].join(','),
+            returnGeometry: 'false',
+            f: 'json'
+        });
+
+        try {
+            const response = await fetch(`${ARCGIS_FIRE_RESTRICTIONS_URL}?${params}`);
+            if (!response.ok) throw new Error(`ArcGIS Fire_Restrictions ${response.status}`);
+            const data = await response.json();
+            const features = Array.isArray(data?.features) ? data.features : [];
+            const restrictions = features
+                .map(normalizeFeature)
+                .sort((a, b) => {
+                    const aT = a.effectiveAt ? Date.parse(a.effectiveAt) : 0;
+                    const bT = b.effectiveAt ? Date.parse(b.effectiveAt) : 0;
+                    if (aT !== bT) return bT - aT;
+                    return (a.agency || '').localeCompare(b.agency || '');
+                });
+            cache.set(cacheKey, restrictions);
+            return restrictions;
+        } catch (error) {
+            console.error('Error fetching Utah fire restrictions:', error.message);
+            return [];
+        }
+    }
+}
+
+export default FireRestrictionsService;

--- a/server/fireWeatherService.js
+++ b/server/fireWeatherService.js
@@ -1,0 +1,365 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fetch from 'node-fetch';
+import NodeCache from 'node-cache';
+import { fetchNWSGridpointForecast, nwsFetch, NWS_USER_AGENT } from './nwsHelpers.js';
+import { clusterDetections, categorizeAndConfirm } from './fireClustering.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const cache = new NodeCache({ stdTTL: 300 });
+
+export const UINTA_BASIN_BBOX = { west: -111.5, south: 39.5, east: -108.5, north: 41.0 };
+export const UINTA_BASIN_CENTROID = { lat: 40.3033, lon: -109.7 };
+
+// HDW thresholds derived from Srock, Charney, Potter, Goodrick (2018),
+// "The Hot-Dry-Windy Index: A New Fire Weather Index", Atmosphere 9(7), 279.
+// Surface implementation: HDW = VPD_kPa * max(wind, gust) in m/s.
+export const HDW_THRESHOLDS = {
+    low: 5,         // < 5
+    moderate: 15,   // 5 - 14.99
+    high: 30,       // 15 - 29.99
+    very_high: 50,  // 30 - 49.99
+    extreme: Infinity
+};
+
+let firmsKeyWarned = false;
+
+function classifyHDW(hdw) {
+    if (hdw == null || !Number.isFinite(hdw)) return null;
+    if (hdw < HDW_THRESHOLDS.low) return 'low';
+    if (hdw < HDW_THRESHOLDS.moderate) return 'moderate';
+    if (hdw < HDW_THRESHOLDS.high) return 'high';
+    if (hdw < HDW_THRESHOLDS.very_high) return 'very_high';
+    return 'extreme';
+}
+
+function saturationVaporPressureKpa(tempC) {
+    return 0.6108 * Math.exp((17.27 * tempC) / (tempC + 237.3));
+}
+
+function rhFromTempAndDewpoint(tempC, dewpointC) {
+    if (tempC == null || dewpointC == null) return null;
+    const es = saturationVaporPressureKpa(tempC);
+    const e = saturationVaporPressureKpa(dewpointC);
+    if (es <= 0) return null;
+    const rh = (e / es) * 100;
+    return Math.max(0, Math.min(100, rh));
+}
+
+class FireWeatherService {
+    constructor() {
+        this.nwsUserAgent = NWS_USER_AGENT;
+        this.firmsKey = process.env.FIRMS_MAP_KEY || null;
+    }
+
+    // ── Hot-Dry-Windy Index ────────────────────────────────────────────
+    /**
+     * Compute HDW from surface variables.
+     *
+     * @param {number} tempC - air temperature, °C
+     * @param {number} rhPercent - relative humidity, %
+     * @param {number} windMs - wind speed (or max(speed, gust)) in m/s
+     * @returns {{hdw:number, vpdKpa:number, level:string} | null}
+     *
+     * Citation: Srock et al. 2018, Atmosphere 9(7), 279. doi:10.3390/atmos9070279.
+     * Surface approximation: VPD at 2m * 10m wind (Srock §2.2).
+     */
+    computeHDW(tempC, rhPercent, windMs) {
+        if (tempC == null || rhPercent == null || windMs == null) return null;
+        if (!Number.isFinite(tempC) || !Number.isFinite(rhPercent) || !Number.isFinite(windMs)) return null;
+        const es = saturationVaporPressureKpa(tempC);
+        const e = es * (rhPercent / 100);
+        const vpd = Math.max(0, es - e);
+        const hdw = vpd * windMs;
+        return { hdw, vpdKpa: vpd, level: classifyHDW(hdw) };
+    }
+
+    // ── NWS Red Flag Warnings + Fire Weather Watches ───────────────────
+    async fetchRedFlagAlerts() {
+        const cacheKey = 'nws_fire_alerts_ut';
+        const cached = cache.get(cacheKey);
+        if (cached) return cached;
+
+        try {
+            const [redFlag, watch] = await Promise.all([
+                nwsFetch('https://api.weather.gov/alerts/active?event=Red+Flag+Warning&area=UT').catch(() => ({ features: [] })),
+                nwsFetch('https://api.weather.gov/alerts/active?event=Fire+Weather+Watch&area=UT').catch(() => ({ features: [] }))
+            ]);
+            const features = [...(redFlag.features || []), ...(watch.features || [])];
+            const basinKeywords = /(uinta|uintah|duchesne)/i;
+            const alerts = features
+                .filter(f => basinKeywords.test(f.properties?.areaDesc || ''))
+                .map(f => ({
+                    id: f.properties?.id || f.id,
+                    event: f.properties?.event || 'Fire Weather',
+                    headline: f.properties?.headline || '',
+                    description: f.properties?.description || '',
+                    instruction: f.properties?.instruction || '',
+                    effective: f.properties?.effective || null,
+                    expires: f.properties?.expires || null,
+                    areaDesc: f.properties?.areaDesc || '',
+                    severity: f.properties?.severity || null,
+                    urgency: f.properties?.urgency || null
+                }))
+                .sort((a, b) => (new Date(b.effective || 0)) - (new Date(a.effective || 0)));
+            cache.set(cacheKey, alerts);
+            return alerts;
+        } catch (error) {
+            console.error('Error fetching NWS fire alerts:', error.message);
+            return [];
+        }
+    }
+
+    // ── NWS gridpoint forecast (delegates to shared helper) ────────────
+    async fetchNWSFireWeatherForecast(lat, lon) {
+        const cacheKey = `fire_nws_${lat}_${lon}`;
+        const cached = cache.get(cacheKey);
+        if (cached) return cached;
+        try {
+            const data = await fetchNWSGridpointForecast(lat, lon);
+            cache.set(cacheKey, data);
+            return data;
+        } catch (error) {
+            console.error('Error fetching NWS fire forecast:', error.message);
+            return null;
+        }
+    }
+
+    // ── Open-Meteo fire-weather variables ──────────────────────────────
+    async fetchOpenMeteoFireVars(lat, lon) {
+        const cacheKey = `fire_openmeteo_${lat}_${lon}`;
+        const cached = cache.get(cacheKey);
+        if (cached) return cached;
+        try {
+            const url = 'https://api.open-meteo.com/v1/forecast?' +
+                `latitude=${lat}&longitude=${lon}` +
+                '&current=temperature_2m,relative_humidity_2m,dew_point_2m,' +
+                'wind_speed_10m,wind_gusts_10m,wind_direction_10m,' +
+                'vapor_pressure_deficit,precipitation' +
+                '&hourly=temperature_2m,relative_humidity_2m,dew_point_2m,' +
+                'wind_speed_10m,wind_gusts_10m,vapor_pressure_deficit' +
+                '&forecast_hours=48&wind_speed_unit=ms&timezone=America/Denver';
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(`Open-Meteo error: ${response.status}`);
+            const data = await response.json();
+            cache.set(cacheKey, data);
+            return data;
+        } catch (error) {
+            console.error('Error fetching Open-Meteo fire vars:', error.message);
+            return null;
+        }
+    }
+
+    // ── NASA FIRMS active-fire hotspots ────────────────────────────────
+    async fetchFIRMSHotspots(bbox = UINTA_BASIN_BBOX, dayRange = 3) {
+        if (!this.firmsKey) {
+            if (!firmsKeyWarned) {
+                console.warn('FIRMS_MAP_KEY not set — FIRMS hotspot layer disabled. Set FIRMS_MAP_KEY in .env to enable.');
+                firmsKeyWarned = true;
+            }
+            return [];
+        }
+        const cacheKey = `firms_${bbox.west}_${bbox.south}_${bbox.east}_${bbox.north}_${dayRange}`;
+        const cached = cache.get(cacheKey);
+        if (cached) return cached;
+        try {
+            const coords = `${bbox.west},${bbox.south},${bbox.east},${bbox.north}`;
+            const url = `https://firms.modaps.eosdis.nasa.gov/api/area/csv/${this.firmsKey}/VIIRS_NOAA20_NRT/${coords}/${dayRange}`;
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(`FIRMS API error: ${response.status}`);
+            const text = await response.text();
+            const hotspots = parseFIRMSCsv(text);
+            cache.set(cacheKey, hotspots, 1800);
+            return hotspots;
+        } catch (error) {
+            console.error('Error fetching FIRMS hotspots:', error.message);
+            return [];
+        }
+    }
+
+    // ── Clustered fires from FIRMS hotspots ────────────────────────────
+    async getBasinFires(bbox = UINTA_BASIN_BBOX) {
+        const hotspots = await this.fetchFIRMSHotspots(bbox);
+        const clusters = clusterDetections(hotspots);
+        return categorizeAndConfirm(clusters, Date.now());
+    }
+
+    // ── Live basin observations (read from local static file) ─────────
+    async readLatestBasinObservations() {
+        try {
+            const staticDir = path.join(__dirname, '../public/api/static');
+            const obsDir = path.join(staticDir, 'observations');
+            const metaDir = path.join(staticDir, 'metadata');
+
+            const obsFiles = fs.readdirSync(obsDir).filter(f => f.startsWith('map_obs_') && f.endsWith('.json') && !f.includes('meta'));
+            if (obsFiles.length === 0) return { observations: [], metadata: {} };
+            const latestObs = obsFiles.sort().reverse()[0];
+            const obsData = JSON.parse(fs.readFileSync(path.join(obsDir, latestObs), 'utf8'));
+
+            const metaFiles = fs.readdirSync(metaDir).filter(f => f.startsWith('map_obs_meta_') && f.endsWith('.json'));
+            const metaData = metaFiles.length > 0
+                ? JSON.parse(fs.readFileSync(path.join(metaDir, metaFiles.sort().reverse()[0]), 'utf8'))
+                : [];
+            const metaByStid = {};
+            for (const m of metaData) {
+                metaByStid[m.stid] = m;
+            }
+            return { observations: obsData, metadata: metaByStid };
+        } catch (error) {
+            console.error('Error reading basin observations:', error.message);
+            return { observations: [], metadata: {} };
+        }
+    }
+
+    // ── Per-station HDW computation ────────────────────────────────────
+    computeStationHDW(observations, metadata) {
+        const byStid = {};
+        for (const row of observations) {
+            if (!byStid[row.stid]) byStid[row.stid] = {};
+            byStid[row.stid][row.variable] = row.value;
+            byStid[row.stid]._date = row.date_time;
+        }
+            const stations = [];
+        for (const [stid, vars] of Object.entries(byStid)) {
+            const meta = metadata[stid];
+            if (!meta) continue;
+            const lat = meta.latitude;
+            const lon = meta.longitude;
+            if (lat == null || lon == null) continue;
+            if (lat < UINTA_BASIN_BBOX.south || lat > UINTA_BASIN_BBOX.north) continue;
+            if (lon < UINTA_BASIN_BBOX.west || lon > UINTA_BASIN_BBOX.east) continue;
+
+            const tempC = vars.air_temp;
+            const dewC = vars.dew_point_temperature;
+            const windMs = vars.wind_speed;
+            const rh = rhFromTempAndDewpoint(tempC, dewC);
+            const hdwResult = this.computeHDW(tempC, rh, windMs);
+
+            stations.push({
+                stid,
+                name: meta.name || stid,
+                lat,
+                lng: lon,
+                elevation: meta.elevation || null,
+                tempC,
+                dewC,
+                rh,
+                windMs,
+                date: vars._date || null,
+                hdw: hdwResult ? hdwResult.hdw : null,
+                hdwLevel: hdwResult ? hdwResult.level : null
+            });
+        }
+        return stations;
+    }
+
+    // ── Aggregated snapshot for the /fire page ─────────────────────────
+    async getBasinFireWeatherSnapshot() {
+        const cacheKey = 'fire_basin_snapshot';
+        const cached = cache.get(cacheKey);
+        if (cached) return cached;
+
+        const [openMeteo, alerts, hotspots, forecast, obsBundle] = await Promise.all([
+            this.fetchOpenMeteoFireVars(UINTA_BASIN_CENTROID.lat, UINTA_BASIN_CENTROID.lon),
+            this.fetchRedFlagAlerts(),
+            this.fetchFIRMSHotspots(),
+            this.fetchNWSFireWeatherForecast(UINTA_BASIN_CENTROID.lat, UINTA_BASIN_CENTROID.lon),
+            Promise.resolve(this.readLatestBasinObservations())
+        ]);
+
+        const stations = this.computeStationHDW(obsBundle.observations, obsBundle.metadata);
+
+        let stationMax = null;
+        for (const s of stations) {
+            if (s.hdw != null && (stationMax == null || s.hdw > stationMax.hdw)) {
+                stationMax = s;
+            }
+        }
+
+        let basin = null;
+        if (openMeteo && openMeteo.current) {
+            const c = openMeteo.current;
+            const wind = Math.max(c.wind_speed_10m ?? 0, c.wind_gusts_10m ?? 0);
+            const centroidHdw = this.computeHDW(c.temperature_2m, c.relative_humidity_2m, wind);
+            const stationHdw = stationMax?.hdw ?? null;
+            const overallHdw = stationHdw != null && centroidHdw
+                ? Math.max(stationHdw, centroidHdw.hdw)
+                : (centroidHdw?.hdw ?? stationHdw);
+            basin = {
+                tempC: c.temperature_2m,
+                rhPercent: c.relative_humidity_2m,
+                dewPointC: c.dew_point_2m,
+                windMs: c.wind_speed_10m,
+                gustMs: c.wind_gusts_10m,
+                windDirDeg: c.wind_direction_10m,
+                vpdKpa: c.vapor_pressure_deficit,
+                hdw: overallHdw,
+                hdwLevel: classifyHDW(overallHdw),
+                hdwSource: stationHdw != null && stationHdw >= (centroidHdw?.hdw ?? -Infinity)
+                    ? `station ${stationMax.name}`
+                    : 'basin centroid (Open-Meteo)',
+                observedAt: new Date().toISOString()
+            };
+        }
+
+        const clusters = clusterDetections(hotspots);
+        const fires = categorizeAndConfirm(clusters, Date.now());
+
+        const snapshot = {
+            success: true,
+            timestamp: new Date().toISOString(),
+            basin,
+            stations,
+            stationMax,
+            hotspots,
+            fires,
+            alerts,
+            forecast: forecast?.periods || [],
+            hourly: openMeteo?.hourly || null
+        };
+        cache.set(cacheKey, snapshot, 300);
+        return snapshot;
+    }
+}
+
+// ── CSV parser for FIRMS responses ─────────────────────────────────────
+function parseFIRMSCsv(text) {
+    if (!text || typeof text !== 'string') return [];
+    const lines = text.split(/\r?\n/).filter(Boolean);
+    if (lines.length < 2) return [];
+    const header = lines[0].split(',').map(h => h.trim());
+    const rows = [];
+    for (let i = 1; i < lines.length; i++) {
+        const cols = lines[i].split(',');
+        if (cols.length !== header.length) continue;
+        const obj = {};
+        for (let j = 0; j < header.length; j++) {
+            obj[header[j]] = cols[j];
+        }
+        const lat = parseFloat(obj.latitude);
+        const lon = parseFloat(obj.longitude);
+        if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+        rows.push({
+            lat,
+            lon,
+            brightness: parseFloat(obj.bright_ti4 || obj.brightness) || null,
+            scan: parseFloat(obj.scan) || null,
+            track: parseFloat(obj.track) || null,
+            acqDate: obj.acq_date || null,
+            acqTime: obj.acq_time || null,
+            satellite: obj.satellite || null,
+            instrument: obj.instrument || null,
+            confidence: obj.confidence || null,
+            version: obj.version || null,
+            brightT31: parseFloat(obj.bright_ti5 || obj.bright_t31) || null,
+            frp: parseFloat(obj.frp) || null,
+            daynight: obj.daynight || null
+        });
+    }
+    return rows;
+}
+
+export default FireWeatherService;

--- a/server/nwsHelpers.js
+++ b/server/nwsHelpers.js
@@ -1,0 +1,29 @@
+import fetch from 'node-fetch';
+
+export const NWS_USER_AGENT = 'BasinWX/1.0 (basinwx.com)';
+
+export async function nwsFetch(url) {
+    const response = await fetch(url, {
+        headers: {
+            'User-Agent': NWS_USER_AGENT,
+            'Accept': 'application/json'
+        }
+    });
+    if (!response.ok) {
+        throw new Error(`NWS API error: ${response.status} for ${url}`);
+    }
+    return response.json();
+}
+
+export async function fetchNWSGridpointForecast(lat, lon) {
+    const points = await nwsFetch(`https://api.weather.gov/points/${lat},${lon}`);
+    const forecastUrl = points.properties.forecast;
+    const forecast = await nwsFetch(forecastUrl);
+    const periods = forecast.properties.periods;
+    return {
+        current: periods[0],
+        upcoming: periods.slice(1, 5),
+        periods,
+        raw: forecast
+    };
+}

--- a/server/roadWeatherService.js
+++ b/server/roadWeatherService.js
@@ -3,6 +3,7 @@ import path from 'path';
 import fetch from 'node-fetch';
 import NodeCache from 'node-cache';
 import SnowDetectionService from './snowDetectionService.js';
+import { fetchNWSGridpointForecast } from './nwsHelpers.js';
 
 const cache = new NodeCache({ stdTTL: 300 });
 
@@ -165,41 +166,8 @@ class RoadWeatherService {
         if (cached) return cached;
 
         try {
-            const pointsUrl = `https://api.weather.gov/points/${lat},${lon}`;
-            const pointsResponse = await fetch(pointsUrl, {
-                headers: {
-                    'User-Agent': this.nwsUserAgent,
-                    'Accept': 'application/json'
-                }
-            });
-
-            if (!pointsResponse.ok) {
-                throw new Error(`NWS API error: ${pointsResponse.status}`);
-            }
-
-            const pointsData = await pointsResponse.json();
-            const forecastUrl = pointsData.properties.forecast;
-
-            const forecastResponse = await fetch(forecastUrl, {
-                headers: {
-                    'User-Agent': this.nwsUserAgent,
-                    'Accept': 'application/json'
-                }
-            });
-
-            if (!forecastResponse.ok) {
-                throw new Error(`NWS Forecast error: ${forecastResponse.status}`);
-            }
-
-            const forecastData = await forecastResponse.json();
-            const periods = forecastData.properties.periods;
-
-            const processedForecast = {
-                current: periods[0],
-                upcoming: periods.slice(1, 5),
-                warnings: []
-            };
-
+            const { current, upcoming } = await fetchNWSGridpointForecast(lat, lon);
+            const processedForecast = { current, upcoming, warnings: [] };
             cache.set(cacheKey, processedForecast);
             return processedForecast;
         } catch (error) {

--- a/server/routes/fireRestrictions.js
+++ b/server/routes/fireRestrictions.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import FireRestrictionsService from '../fireRestrictionsService.js';
+
+const router = express.Router();
+let fireRestrictionsService = new FireRestrictionsService();
+
+export function setFireRestrictionsService(service) {
+    fireRestrictionsService = service;
+}
+
+router.get('/fire-restrictions', async (req, res) => {
+    try {
+        const restrictions = await fireRestrictionsService.fetchActiveRestrictions();
+        res.json({
+            success: true,
+            timestamp: new Date().toISOString(),
+            totalRestrictions: restrictions.length,
+            restrictions
+        });
+    } catch (error) {
+        console.error('Error in /fire-restrictions endpoint:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to fetch fire restrictions',
+            message: error.message
+        });
+    }
+});
+
+export default router;

--- a/server/routes/fireWeather.js
+++ b/server/routes/fireWeather.js
@@ -1,0 +1,89 @@
+import express from 'express';
+import FireWeatherService from '../fireWeatherService.js';
+
+const router = express.Router();
+let fireWeatherService = new FireWeatherService();
+
+export function setFireWeatherService(service) {
+    fireWeatherService = service;
+}
+
+router.get('/fire-weather', async (req, res) => {
+    try {
+        const snapshot = await fireWeatherService.getBasinFireWeatherSnapshot();
+        res.json(snapshot);
+    } catch (error) {
+        console.error('Error in /fire-weather endpoint:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to build fire weather snapshot',
+            message: error.message
+        });
+    }
+});
+
+router.get('/fire-weather/alerts', async (req, res) => {
+    try {
+        const alerts = await fireWeatherService.fetchRedFlagAlerts();
+        res.json({
+            success: true,
+            timestamp: new Date().toISOString(),
+            totalAlerts: alerts.length,
+            alerts
+        });
+    } catch (error) {
+        console.error('Error fetching fire alerts:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to fetch fire alerts',
+            message: error.message
+        });
+    }
+});
+
+router.get('/fire-weather/hotspots', async (req, res) => {
+    try {
+        const hotspots = await fireWeatherService.fetchFIRMSHotspots();
+        res.json({
+            success: true,
+            timestamp: new Date().toISOString(),
+            totalHotspots: hotspots.length,
+            hotspots
+        });
+    } catch (error) {
+        console.error('Error fetching FIRMS hotspots:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to fetch FIRMS hotspots',
+            message: error.message
+        });
+    }
+});
+
+router.get('/fire-weather/forecast/:lat/:lon', async (req, res) => {
+    try {
+        const lat = parseFloat(req.params.lat);
+        const lon = parseFloat(req.params.lon);
+        if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+            return res.status(400).json({ success: false, error: 'Invalid lat/lon' });
+        }
+        const forecast = await fireWeatherService.fetchNWSFireWeatherForecast(lat, lon);
+        if (!forecast) {
+            return res.status(502).json({ success: false, error: 'NWS forecast unavailable' });
+        }
+        res.json({
+            success: true,
+            timestamp: new Date().toISOString(),
+            ...forecast
+        });
+    } catch (error) {
+        console.error('Error fetching NWS fire forecast:', error);
+        res.status(500).json({
+            success: false,
+            error: 'Failed to fetch NWS fire forecast',
+            message: error.message
+        });
+    }
+});
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,8 @@ import dataUploadRoutes from './routes/dataUpload.js';
 import roadWeatherRoutes, { setRoadWeatherService } from './routes/roadWeather.js';
 import trafficEventsRoutes, { setTrafficEventsService } from './routes/trafficEvents.js';
 import synopticAPIRoutes from './routes/synopticAPI.js';
+import fireWeatherRoutes from './routes/fireWeather.js';
+import fireRestrictionsRoutes from './routes/fireRestrictions.js';
 import BackgroundRefreshService from './backgroundRefresh.js';
 import analyticsMiddleware, { getAnalyticsStats } from './middleware/analytics.js';
 import { getMonitor } from './monitoring/dataMonitor.js';
@@ -45,6 +47,8 @@ app.use('/api', dataUploadRoutes);
 app.use('/api', roadWeatherRoutes);
 app.use('/api', trafficEventsRoutes);
 app.use('/api', synopticAPIRoutes);
+app.use('/api', fireWeatherRoutes);
+app.use('/api', fireRestrictionsRoutes);
 app.use('/api/static', express.static(path.join(__dirname, '../public/api/static')));
 
 // Analytics stats endpoint (protected by environment check)

--- a/views/fire.html
+++ b/views/fire.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Fire Weather: Uintah Basin">
-    <title>BasinWx</title>
+    <title>BasinWx — Fire Weather</title>
     <link rel="icon" type="image/x-icon" href="/public/images/favicons/gemini-b2.ico">
 
     <!-- Google Fonts -->
@@ -16,6 +16,12 @@
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 
+    <!-- Leaflet -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+
+    <!-- Plotly -->
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+
     <!-- CSS -->
     <link rel="stylesheet" href="/public/css/main.css">
     <link rel="stylesheet" href="/public/css/fire.css">
@@ -24,8 +30,7 @@
 <body data-page-type="fire">
 
 <!-- Colored Bar -->
-<div class="colored-bar">
-</div>
+<div class="colored-bar"></div>
 
 <!-- Sidebar Container -->
 <div class="sidebar_container">
@@ -33,32 +38,152 @@
 </div>
 
 <!-- Main Content -->
-<main class="content">
-    <!-- Coming Soon Overlay -->
-    <div class="coming-soon-overlay">
-        <h2>Coming Soon</h2>
-        <p>Fire weather forecasts launching December 2025</p>
-    </div>
+<main class="content" role="main">
+    <h1>Fire Weather</h1>
 
-    <h1>Fire Forecasts</h1>
+    <!-- Red Flag banner (populated by JS) -->
+    <section id="red-flag-banner" class="red-flag-banner is-hidden" aria-live="polite" aria-atomic="true" hidden></section>
 
-<!-- Forecast Sections -->
-<div class="forecast-container">
-    <!--  -->
-    <section class="forecast-section">
-        <h2><i class="fas fa-fire"></i> Hazard level, Uinta Basin</h2>
+    <!-- Active fire restrictions (populated by JS; hidden when none in effect) -->
+    <section id="fire-restrictions-panel" class="restrictions-section" aria-label="Active fire restrictions intersecting the Uinta Basin" hidden>
+        <h2><i class="fas fa-ban" aria-hidden="true"></i> Active Fire Restrictions</h2>
+        <p class="restrictions-intro">Orders currently in effect that overlap the Uinta Basin. Source: Utah Fire Info / DNR Fire Restrictions.</p>
+        <div id="fire-restrictions-list" class="restrictions-list"></div>
+    </section>
 
-        <div class="forecast-content">
-            <div class="placeholder-content">
-                <p>Some kind of fire product.</p>
-                <div class="chart-placeholder">
-                    <i class="fas fa-chart-line fa-3x"></i>
-                    <p>Fire weather chart</p>
-                </div>
-            </div>
+    <!-- Hero: basin-wide HDW + snapshot -->
+    <section class="fire-hero" aria-label="Current basin fire-weather summary">
+        <div class="hero-hdw">
+            <span class="hdw-label">Hot-Dry-Windy Index</span>
+            <span class="hdw-level-badge" id="basin-hdw-badge" data-level="loading">
+                <span class="hdw-value" id="basin-hdw-value">--</span>
+                <span class="hdw-level-name" id="basin-hdw-level-name">Loading</span>
+            </span>
+            <span class="hdw-source" id="basin-hdw-source"></span>
+        </div>
+        <div class="hero-side">
+            <p class="hero-snapshot" id="hero-snapshot">Loading current basin conditions…</p>
+            <span id="hotspot-count-chip" class="hotspot-count-chip is-hidden" hidden>
+                <i class="fas fa-fire-flame-curved" aria-hidden="true"></i>
+                <span id="hotspot-count-value">0</span> active satellite detections, 24h
+            </span>
         </div>
     </section>
-</div>
+
+    <!-- Live conditions grid -->
+    <section class="weather-summary" aria-label="Live basin conditions">
+        <div class="summary-grid">
+            <article class="condition-card">
+                <div class="card-icon"><i class="fas fa-temperature-high" aria-hidden="true"></i></div>
+                <div class="card-content">
+                    <h3>Temperature</h3>
+                    <p class="current-value" id="card-temp">--</p>
+                    <p class="trend" id="card-temp-trend">basin centroid</p>
+                </div>
+            </article>
+            <article class="condition-card">
+                <div class="card-icon"><i class="fas fa-tint" aria-hidden="true"></i></div>
+                <div class="card-content">
+                    <h3>Relative Humidity</h3>
+                    <p class="current-value" id="card-rh">--</p>
+                    <p class="trend" id="card-rh-trend">basin centroid</p>
+                </div>
+            </article>
+            <article class="condition-card">
+                <div class="card-icon"><i class="fas fa-wind" aria-hidden="true"></i></div>
+                <div class="card-content">
+                    <h3>Wind &amp; Gusts</h3>
+                    <p class="current-value" id="card-wind">--</p>
+                    <p class="trend" id="card-wind-trend">gust --</p>
+                </div>
+            </article>
+            <article class="condition-card">
+                <div class="card-icon"><i class="fas fa-fire" aria-hidden="true"></i></div>
+                <div class="card-content">
+                    <h3>HDW (max station)</h3>
+                    <p class="current-value" id="card-hdw">--</p>
+                    <p class="trend" id="card-hdw-station">--</p>
+                </div>
+            </article>
+        </div>
+    </section>
+
+    <!-- Map -->
+    <section class="map-section" aria-label="Fire-weather station map and active satellite detections">
+        <h2><i class="fas fa-map-marked-alt" aria-hidden="true"></i> Station Map &amp; Active Detections</h2>
+        <div id="fire-map" class="station-map" role="application" aria-label="Leaflet map of fire-weather stations and FIRMS hotspot detections in the Uinta Basin"></div>
+        <p class="map-legend-text">
+            Station pins colored by HDW class (low → extreme). Red circles are NASA FIRMS VIIRS satellite hotspot detections from the last 24&nbsp;hours; size scales with fire-radiative-power.
+        </p>
+    </section>
+
+    <!-- Detected fires (populated by JS; hidden when none) -->
+    <section id="fire-list-panel" class="fire-list-section" aria-label="Fires detected by NASA FIRMS in the Uinta Basin" hidden>
+        <h2><i class="fas fa-fire" aria-hidden="true"></i> Detected Fires</h2>
+        <p class="fire-list-intro">
+            Clusters of NASA FIRMS satellite hotspot detections in the Uinta Basin.
+            <strong>Active</strong> = detected within the last 12&nbsp;hours;
+            <strong>Recent</strong> = within 72&nbsp;hours.
+            Single low-confidence detections are filtered out as likely noise.
+        </p>
+        <article class="fire-list-group" id="active-fires-group">
+            <h3>Active <span class="fire-list-count" id="active-fires-count">0</span></h3>
+            <div id="active-fires-list" class="fire-list-grid"></div>
+        </article>
+        <article class="fire-list-group" id="recent-fires-group">
+            <h3>Recent <span class="fire-list-count" id="recent-fires-count">0</span></h3>
+            <div id="recent-fires-list" class="fire-list-grid"></div>
+        </article>
+    </section>
+
+    <!-- NWS forecast strip -->
+    <section class="forecast-section" aria-label="National Weather Service basin forecast">
+        <h2><i class="fas fa-cloud-sun" aria-hidden="true"></i> NWS Forecast (Basin Centroid)</h2>
+        <div id="forecast-strip" class="forecast-strip">
+            <div class="loading-spinner"><i class="fas fa-spinner fa-spin" aria-hidden="true"></i><span>Loading forecast…</span></div>
+        </div>
+    </section>
+
+    <!-- Meteogram -->
+    <section class="forecast-section" aria-label="48-hour meteogram">
+        <h2><i class="fas fa-chart-area" aria-hidden="true"></i> 48-Hour Meteogram</h2>
+        <div id="meteogram" class="meteogram-chart"></div>
+    </section>
+
+    <!-- Preparedness -->
+    <section class="preparedness-section" aria-labelledby="prep-heading">
+        <h2 id="prep-heading"><i class="fas fa-shield-alt" aria-hidden="true"></i> Wildfire Preparedness</h2>
+        <ul class="preparedness-grid">
+            <li><strong>Defensible space.</strong> Maintain at least 30&nbsp;ft of cleared, well-watered vegetation around structures; 100&nbsp;ft on slopes.</li>
+            <li><strong>Burn restrictions.</strong> Any currently-in-effect orders for the basin are listed at the top of this page. Check <a href="https://utahfireinfo.gov/" target="_blank" rel="noopener noreferrer">Utah Fire Info</a> for the full statewide picture. Restrictions tighten on Red Flag days.</li>
+            <li><strong>Evacuation plan.</strong> Know two escape routes from your area, and a rendezvous point off the canyon.</li>
+            <li><strong>Go-bag.</strong> 72&nbsp;hours of water, meds, documents, N95s, and pet supplies near the door during Red Flag periods.</li>
+            <li><strong>Report new fires.</strong> Call 911 immediately. Note the location, smoke color, and any visible flames.</li>
+        </ul>
+    </section>
+
+    <!-- Resources -->
+    <section class="resources-section" aria-label="External fire-weather resources">
+        <h2><i class="fas fa-external-link-alt" aria-hidden="true"></i> Resources</h2>
+        <div class="resources-grid">
+            <a class="resource-card" href="https://utahfireinfo.gov/" target="_blank" rel="noopener noreferrer">
+                <h3>Utah Fire Info</h3>
+                <p>Statewide restrictions, active incidents, prevention.</p>
+            </a>
+            <a class="resource-card" href="https://www.weather.gov/fire/" target="_blank" rel="noopener noreferrer">
+                <h3>NWS Fire Weather</h3>
+                <p>Official forecasts, watches, and Red Flag warnings.</p>
+            </a>
+            <a class="resource-card" href="https://inciweb.wildfire.gov/" target="_blank" rel="noopener noreferrer">
+                <h3>InciWeb</h3>
+                <p>National incident information system.</p>
+            </a>
+            <a class="resource-card" href="https://firms.modaps.eosdis.nasa.gov/map/" target="_blank" rel="noopener noreferrer">
+                <h3>NASA FIRMS</h3>
+                <p>Source of the satellite hotspots on our map.</p>
+            </a>
+        </div>
+    </section>
 </main>
 
 <!-- Footer -->
@@ -69,9 +194,20 @@
 </footer>
 
 <!-- Scripts -->
-<script type="module" src="/public/js/fire.js"></script>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script type="module" src="/public/js/loadSidebar.js"></script>
 <script type="module" src="/public/js/loadFooter.js"></script>
+<script src="/public/js/fire/HDWClassifier.js"></script>
+<script src="/public/js/fire/FireDataCache.js"></script>
+<script src="/public/js/fire/FireWeatherMap.js"></script>
+<script src="/public/js/fire/HotspotLayer.js"></script>
+<script src="/public/js/fire/AlertsBanner.js"></script>
+<script src="/public/js/fire/Meteogram.js"></script>
+<script src="/public/js/fire/RestrictionsPanel.js"></script>
+<script src="/public/js/fire/FireListPanel.js"></script>
+<script src="/public/js/fire/initialization.js"></script>
+<link rel="stylesheet" href="/public/css/easter-eggs.css">
+<script src="/public/js/easter-eggs.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- /fire goes from stub to live: HDW hero, station map, NWS Red Flag, 48h meteogram
- Live Utah DNR burn-restriction lookup with team-written order summaries
- FIRMS hotspots clustered into fires with active/recent lifecycle, red map overlay, per-fire cards

## Test plan
- [ ] `npm test` — clustering spec (24 cases) all green
- [ ] Visit `/fire` on preview; confirm hero, map, restriction card, fire card visible
- [ ] `/api/fire-weather` includes `fires: {active, recent}`; `/api/fire-restrictions` returns active orders
- [ ] Homepage and other pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)