### PR TITLE
chore: bump version to v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ubair-website",
-  "version": "1.5.0-dev",
+  "version": "1.5.0",
   "description": "Uintah Basin Air Quality Website",
   "main": "server/server.js",
   "type": "module",


### PR DESCRIPTION
Release train **2/5** — merge after #193, before the dev→ops promotion PR.

Strips the `-dev` suffix from `package.json` (`1.5.0-dev` → `1.5.0`) so `ops` ships a clean version string, per the versioning scheme documented in `docs/DEPLOYMENT.md` §7a: `dev` carries the next version with a `-dev` suffix; the suffix is stripped on `dev` immediately before promotion so the promotion itself is a clean branch merge (no recurring `package.json` conflict on future promotions).

Note: until #193 lands on `dev`, this PR's diff also shows #193's commits — it was cut from that branch to avoid a version-line conflict. Net change once #193 merges: one line.
