### PR TITLE
chore: open v1.5.1-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ubair-website",
-  "version": "1.5.0",
+  "version": "1.5.1-dev",
   "description": "Uintah Basin Air Quality Website",
   "main": "server/server.js",
   "type": "module",


### PR DESCRIPTION
Release train **5/5** — merge LAST, after the dev→ops promotion (#196) and the ops→main release merge.

Reopens `dev` at `1.5.1-dev` per the versioning scheme: `dev` always carries the next version with a `-dev` suffix, so the two boxes never report the same version string. Patch-next (`1.5.1`) chosen because the next website cycle's scope is unknown — re-bump to `1.6.0-dev` if a minor-worthy feature lands first.

Cut from the v1.5.0 bump branch; net change once its predecessors land: one line.
