### PR TITLE
docs(deployment): record deployed prod topology; add dev-box handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,23 @@ Live air-quality observations and forecasts for the Uintah Basin. Node/Express +
 Leaflet/Plotly, vanilla JS frontend.
 
 ## Topology
-| Role | Branch | Domain | pm2 app |
-|---|---|---|---|
-| Production | `ops` | `www.basinwx.com` | `basinwx-ops` |
-| Rehearsal mirror | `dev` | `www.basinwx.dev` | `basinwx-dev` |
+| Role | Branch | Domain | pm2 app | Repo path | User |
+|---|---|---|---|---|---|
+| Production | `ops` | `www.basinwx.com` | `ubair-site` | `/var/www/ubair-website` | `root` |
+| Rehearsal mirror | `dev` | `www.basinwx.dev` | *unverified* | *unverified* | *unverified* |
 
-Both: Linode, repo at `/srv/ubair-website` as `deploy`, nginx + Let's Encrypt.
-The pm2 app name is derived from the checked-out branch (`ecosystem.config.cjs`),
-so the branch on disk dictates the running app identity. `.dev` receives the same
-CHPC fan-out as `.com` and is where stakeholder demos happen — merging into `dev` is
-a real-world dry-run before promoting to `ops`.
+Production row verified on linode-prod 2026-08-13. **The dev box has not been inspected** —
+verify before trusting it. `docs/DEPLOYMENT.md` §1b describes a *target* layout
+(`/srv/ubair-website` as `deploy`, pm2 `basinwx-ops` from `ecosystem.config.cjs`) that
+production has **not** been migrated to; §1a records what is actually deployed. Don't quote the
+target as fact.
+
+`.dev` receives the same CHPC fan-out as `.com` and is where stakeholder demos happen —
+merging into `dev` is a real-world dry-run before promoting to `ops`.
+
+**The app serves `public/` off the working tree**, so `git checkout` changes what live traffic
+sees immediately, before any pm2 restart. Never check out a branch in a live repo to inspect or
+stage it — use `git worktree add /tmp/staging <branch>`.
 
 Feature-branch previews live at `<name>.basinwx.dev` (Namecheap wildcard A record),
 managed via `scripts/manage-previews.sh` + `preview-apps.json`. Background jobs are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ Accepted dataTypes (`server/routes/dataUpload.js`):
 Forecast schemas are pinned in `DATA_MANIFEST.json` (canonical contract; brc-tools is
 the contract-holder for new dataTypes — server doesn't enforce schema).
 
+On linode-prod, uploads land from `::ffff:127.0.0.1` with `x-client-hostname:
+notchpeak1.int.chpc.utah.edu` — CHPC reaches port 3000 over **SSH**, not by POSTing to the
+public domain. So a green `/api/health` from outside proves nothing about ingest; the two paths
+are independent. If uploads stop, check the SSH path first (`docs/DEPLOYMENT.md` §1a).
+
 ## Protected branches
 **Never push directly to `dev`, `ops`, or `main`.** All changes go through PRs. If a
 direct push seems warranted, confirm with the user — then ask a **second time** before

--- a/WEBSITE-DEVBOX-HANDOFF-aug13.md
+++ b/WEBSITE-DEVBOX-HANDOFF-aug13.md
@@ -1,0 +1,133 @@
+# WEBSITE → DEVBOX HANDOFF
+# Status: TEMPORARY (delete once §3 passes and §8 is reported back)
+# From: linode-prod (www.basinwx.com), branch `ops` @ v1.5.0
+# To:   linode-dev (www.basinwx.dev)
+# Compiled: 2026-08-13
+# Prereq: apply only after the v1.5.0 release train (#193, #195, #198, #196, #197) has merged.
+
+Compiled **from prod**. The dev box was never inspected — every path, port, and app name below
+is a question, not an instruction. Verify, don't assume.
+
+## Goal
+
+Get `.dev` onto the same v1.5.x contract as prod so it is a real rehearsal mirror again.
+
+## 0. Read this first — the working tree IS the served site
+
+The app serves `public/` straight off the working tree. `git checkout` changes what live traffic
+sees **immediately**, before any pm2 restart. This bit prod during this very deployment: a
+checkout of `dev` in the live repo served dev's frontend against ops's in-memory server for
+~4 minutes.
+
+To inspect or stage a branch without touching the served tree:
+```bash
+git worktree add /tmp/staging <branch>
+```
+
+## 1. Update
+
+```bash
+cd <repo>          # DEPLOYMENT.md §1b guesses /srv/ubair-website — CONFIRM, prod is /var/www
+git fetch origin --prune
+git checkout dev   # only if dev is already the deployed branch; otherwise see §0
+git merge --ff-only origin/dev
+```
+
+`dev` tip carries: pipeline unblockers (#193), v1.5.0 bump (#195), housekeeping (#198 — 25 docs
+archived, dead files pruned), and topology corrections.
+
+**Expected version: `1.5.1-dev`**, once the release train completes (#197 reopens `dev` at the
+next `-dev` after `ops` is tagged `v1.5.0`). If you catch the box mid-train it may read `1.5.0`.
+Per `CLAUDE.md`, `dev` always carries `X.Y.Z-dev` and `ops` ships clean `X.Y.Z`, so the two
+boxes never report the same version — that is how you tell them apart at a glance.
+
+**No `npm ci`.** No dependency changed between the old and new state; `package-lock.json` is
+untracked in this repo.
+
+## 2. Restart
+
+```bash
+pm2 restart <app> && pm2 save
+```
+
+App name is whatever that box already runs — **do not rename it as part of this update.**
+`ecosystem.config.cjs` derives the name from the branch (`basinwx-dev`) but now honours a
+`PM2_APP_NAME` override, so a pre-existing app can adopt the config without a rename:
+`PM2_APP_NAME=<existing> pm2 start ecosystem.config.cjs`. Prod does not use the config file at
+all — it runs a hand-started `ubair-site`. Don't copy prod's layout; just record dev's.
+
+## 3. Verify
+
+```bash
+curl -s http://127.0.0.1:<port>/api/health | jq
+# expect: version "1.5.0" (or "1.5.1-dev"), manifestVersion "1.2.0"
+
+for r in status freshness uploads alerts; do
+  curl -s -o /dev/null -w "$r %{http_code}\n" http://127.0.0.1:<port>/api/monitoring/$r
+done
+# newly mounted this release — 404 means the merge didn't land
+
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:<port>/api/filelist/observations   # 200
+```
+
+Load `/fire`, `/roads`, `/aviation`, `/forecast_air_quality`; check the browser console.
+
+## 4. What changed that dev must match
+
+- **`DATA_MANIFEST.json` → v1.2.0.** Documents `llm_outlooks` (accepted since launch, never
+  written down). The manifest version is now reported by `/api/health` so brc-tools can check
+  contract compatibility for free — **both boxes must report the same value.**
+- **`/api/monitoring/*` mounted** in `server.js`. `POST /api/monitoring/alerts/clear` requires
+  `x-api-key`; the other four are open reads.
+- **`/api/health` returns `version` + `manifestVersion`.** One curl now answers "which box and
+  which contract am I talking to?"
+- **`scripts/chpc_uploader.py`** — the hardcoded `--data-type` allowlist is gone; valid types
+  now come from the manifest. That allowlist was silently blocking `forecasts`,
+  `road-forecast`, and `llm_outlooks`.
+- **`server/keys/data_upload.key` deleted.** It was read by no code and held a dead key. The
+  live key lives only in `.env`.
+
+## 5. Known breakage — same on both boxes, don't re-diagnose
+
+`public/api/static/filelist.json` was deleted, but `GET /api/filelist.json`
+(`server/server.js:131`) still reads it. That endpoint now errors. Nothing consumes it — every
+page uses `/api/filelist/:dataType` — and `scripts/test-api.js` was already moved off it. The
+route is slated for removal.
+
+## 6. `.env` trap — check before debugging any 401
+
+On prod, `BASINWX_API_KEY` ≠ `DATA_UPLOAD_API_KEY`, despite the comment in `.env` claiming they
+match. Ingest is unaffected: the server only ever validates `DATA_UPLOAD_API_KEY`. But
+`chpc_uploader.py` reads `BASINWX_API_KEY`, so running it *from the box* to self-test returns
+401 and reads like an auth regression when nothing is actually wrong.
+
+**Check dev for the same drift.** The only requirement that matters: dev's
+`DATA_UPLOAD_API_KEY` must equal the key CHPC fans out to `.dev`.
+
+## 7. Still broken — and NOT a dev-box problem
+
+Per `WEBSITE-BRCTOOLS-HANDOFF-aug13.md`, fan-out delivers only `observations` + `metadata` to
+`.dev`. `forecasts` / `images` / `llm_outlooks` reach `.com` only, because brc-tools has **≥2
+upload code paths** — one honours `BASINWX_API_URLS`, one hardcodes `.com`. That is brc-tools'
+fix, on CHPC. Receivers never pull; nothing you do on the dev box will fix it.
+
+Must be resolved **before ozone season (~Nov)** or `.dev` runs blind all winter and stops being
+a usable rehearsal mirror.
+
+Also dark on both boxes, awaiting producers — website side is already complete:
+`road-forecast` (start here), `forecast_hrrr_kvel_crosswind`, `forecast_hrrr_surface_layers`.
+
+Separately: `forecasts` / `images` / `llm_outlooks` all stop at exactly `2026-03-30 0600Z` on
+prod. That is the **expected** winter-ozone season wind-down, confirmed by JRL 2026-08-13 — not
+a bug, and not something to chase.
+
+## 8. Report back
+
+So `docs/DEPLOYMENT.md` §1a and `CLAUDE.md` can be corrected for dev the way they were just
+corrected for prod:
+
+- repo path, pm2 app name, port, service user
+- `/api/health` output
+- whether the §6 `.env` drift exists
+- whether `/etc/nginx/sites-enabled/` is populated (on prod it is **empty**, so how traffic
+  reaches port 3000 there is currently undocumented)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,6 +4,36 @@ Canonical runbook for bringing up, operating, and troubleshooting `ubair-website
 
 ## 1. Topology
 
+### 1a. As deployed today (verified 2026-08-13)
+
+| Role | Branch | Domain | pm2 app name | Port | Repo path | Runs as |
+|---|---|---|---|---|---|---|
+| Production | `ops` | `www.basinwx.com` | **`ubair-site`** | `3000` | **`/var/www/ubair-website`** | **`root`** |
+| Rehearsal mirror | `dev` | `www.basinwx.dev` | *unverified* | *unverified* | *unverified* | *unverified* |
+
+Production values confirmed by direct inspection of linode-prod on 2026-08-13 (`pm2 describe`,
+`git rev-parse`, matching on-disk data-file counts). **The dev box was not inspected** — do not
+assume it matches either row until someone verifies it and updates this table. See
+`WEBSITE-DEVBOX-HANDOFF-aug13.md`.
+
+Divergences from the target layout (§1b), on production:
+
+- pm2 app is a **hand-started process named `ubair-site`**, not `basinwx-ops`.
+  `ecosystem.config.cjs` is **not in use** on that box. Renaming a live pm2 app is a deliberate
+  migration, not a side effect of a deploy — see §1c.
+- Repo lives at `/var/www/ubair-website`, owned and run by `root`, not `deploy` under `/srv`.
+- `/etc/nginx/sites-enabled/` is **empty**, so TLS/proxy termination is not set up the way §4
+  describes. Establish how traffic actually reaches port 3000 before touching nginx.
+
+> **Serving caveat — applies to both boxes.** The app serves `public/` straight off the working
+> tree, so `git checkout` changes what live traffic sees **immediately**, before any pm2
+> restart. Never check out another branch in a live repo to inspect or stage it. Use
+> `git worktree add /tmp/staging <branch>` instead, which leaves the deployed tree untouched.
+
+### 1b. Target topology
+
+The layout the rest of this runbook assumes. Production has **not** been migrated to it.
+
 | Role | Branch | Domain | pm2 app name | Typical port | Repo path |
 |---|---|---|---|---|---|
 | Production | `ops` | `www.basinwx.com` | `basinwx-ops` | `3000` | `/srv/ubair-website` |
@@ -11,8 +41,17 @@ Canonical runbook for bringing up, operating, and troubleshooting `ubair-website
 
 - Runtime: Node.js under pm2, started as the `deploy` user.
 - TLS: nginx reverse proxy, Let's Encrypt certs under `/etc/letsencrypt/live/<domain>/`.
-- pm2 app name is **derived from the checked-out branch** (`git rev-parse --abbrev-ref HEAD`). See `ecosystem.config.cjs`.
+- pm2 app name is **derived from the checked-out branch** (`git rev-parse --abbrev-ref HEAD`), overridable via `PM2_APP_NAME`. See `ecosystem.config.cjs`.
 - `www.basinwx.dev` is a **rehearsal mirror** of production: it receives the same CHPC data via fan-out upload, but runs whichever branch is checked out. Merging a PR into `dev` is the dry-run before promoting to `ops`.
+
+### 1c. Migrating production to the target layout
+
+Not part of a routine deploy, and never while pipeline testing is in flight. The `PM2_APP_NAME`
+override exists so `ecosystem.config.cjs` can be adopted *before* committing to a rename —
+`PM2_APP_NAME=ubair-site pm2 start ecosystem.config.cjs` reproduces today's app identity from
+the config file. Renaming afterwards is `pm2 delete` + `pm2 start` + `pm2 save`, which means
+brief downtime and a re-run of `pm2 startup`; verify the app survives a reboot before walking
+away.
 
 ## 2. Deploy vs sudo — user boundary
 
@@ -25,6 +64,9 @@ Canonical runbook for bringing up, operating, and troubleshooting `ubair-website
 | read `.env` | `chmod`/`chown` under `/etc` |
 
 Keep both boxes consistent with this split. `deploy` must own `/srv/ubair-website` recursively.
+
+**Production does not currently follow this split** — it runs as `root` out of
+`/var/www/ubair-website` (§1a). This section describes the target, not today.
 
 ## 3. Fresh-box bring-up
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -22,8 +22,23 @@ Divergences from the target layout (§1b), on production:
   `ecosystem.config.cjs` is **not in use** on that box. Renaming a live pm2 app is a deliberate
   migration, not a side effect of a deploy — see §1c.
 - Repo lives at `/var/www/ubair-website`, owned and run by `root`, not `deploy` under `/srv`.
-- `/etc/nginx/sites-enabled/` is **empty**, so TLS/proxy termination is not set up the way §4
-  describes. Establish how traffic actually reaches port 3000 before touching nginx.
+
+nginx **is** configured and matches §4's intent, just under different vhost filenames:
+
+| Vhost (`sites-enabled/`) | `server_name` | Notes |
+|---|---|---|
+| `ubair` | `www.basinwx.com basinwx.com` + `_` (`default_server`) | certbot cert at `/etc/letsencrypt/live/basinwx.com/` |
+| `172-234-249-49.ip.linodeusercontent.com` | the Linode rDNS host | separate certbot cert |
+
+Both proxy to `upstream ubair_app { server 127.0.0.1:3000; }`. Verified end to end:
+`https://www.basinwx.com/api/health` → 200.
+
+**CHPC uploads arrive over SSH, not from the public internet.** Upload log lines read
+`Access attempt from IP: ::ffff:127.0.0.1, Hostname: notchpeak1.int.chpc.utah.edu` — the source
+is loopback, so the producer reaches port 3000 through an SSH session/tunnel from CHPC rather
+than POSTing to `https://www.basinwx.com`. Consequence: **`/api/health` can be perfectly green
+from the outside while ingest is dead**, because the two paths are unrelated. When uploads stop,
+check the SSH path before touching nginx or the app.
 
 > **Serving caveat — applies to both boxes.** The app serves `public/` straight off the working
 > tree, so `git checkout` changes what live traffic sees **immediately**, before any pm2
@@ -296,3 +311,44 @@ Add an entry to `preview-apps.json` (choose a port not used by any other process
 - **PREVIEW_MODE must be in the branch code, not just the `.env`.** The gate is a guard inside `server/server.js` that checks `process.env.PREVIEW_MODE`. Setting `PREVIEW_MODE=true` in a preview's `.env` only works if the feature branch already contains the gate (merged from `dev`). Until the branch syncs, the preview will still run `backgroundRefresh` + `reportEmailService` and double-poll UDoT / duplicate report emails.
   - **Workaround when the branch is not yet synced with dev:** before running `up`, or immediately after, edit `/srv/ubair-website-preview-<user>/.env` and blank the relevant keys — e.g. `UDOT_API_KEY=` and `REPORT_EMAIL_ENABLED=false` — then `scripts/manage-previews.sh update <user>` (or `pm2 restart <pm2_name>`) to pick them up. Restore them after the branch has synced and `PREVIEW_MODE` is doing its job.
 - Ports are hardcoded in `preview-apps.json`; update the file and the nginx vhost if you need to change a port.
+
+## 10. Gotcha — SSH pubkey auth rejects `ssh-rsa` (observed 2026-08-13)
+
+`/var/log/auth.log` on linode-prod shows, on an hourly `:24` schedule:
+
+```
+sshd[...]: userauth_pubkey: signature algorithm ssh-rsa not in PubkeyAcceptedAlgorithms [preauth]
+```
+
+OpenSSH 8.8+ disables the SHA-1 `ssh-rsa` signature algorithm by default. Any producer or cron
+still offering an RSA key with a SHA-1 signature will fail authentication **silently from the
+client's perspective** — it just looks like the job stopped working.
+
+This matters here because CHPC delivers uploads over SSH (§1a). Check this before blaming the
+app, nginx, or the API key.
+
+Fixes, in order of preference:
+
+1. **Re-key the client to Ed25519** — `ssh-keygen -t ed25519` on the producer, install the
+   public key in the target's `authorized_keys`. Best long-term answer.
+2. **Have the client offer SHA-2 with the existing RSA key** — modern clients negotiate
+   `rsa-sha2-256`/`rsa-sha2-512` automatically; an old client may need upgrading.
+3. **Re-enable SHA-1 on the server (last resort, weakens auth):** add to `/etc/ssh/sshd_config`
+   and reload sshd:
+   ```
+   PubkeyAcceptedAlgorithms +ssh-rsa
+   HostkeyAlgorithms +ssh-rsa
+   ```
+
+Confirm which key the failing job uses before changing anything — `sshd -T | grep -i pubkey`
+shows the server's current accepted list.
+
+## 11. Gotcha — the box is exposed to SSH brute force
+
+`/var/log/auth.log` shows continuous credential stuffing against `root` and common usernames
+from many IPs (dozens of failures per hour). All observed attempts failed, but password auth on
+`root` over the public internet is a standing risk on a box that also holds the pipeline API key.
+
+Worth doing, independent of any deploy: set `PermitRootLogin prohibit-password` and
+`PasswordAuthentication no` in `/etc/ssh/sshd_config` (confirm key-based access works first),
+and consider fail2ban plus a Linode firewall rule restricting port 22 to known ranges.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -20,7 +20,10 @@ const branch = rawBranch
 module.exports = {
   apps: [
     {
-      name: `basinwx-${branch}`,
+      // Branch-derived by default. PM2_APP_NAME overrides it so a box whose pm2 app
+      // predates this file (linode-prod runs `ubair-site`) can adopt the config without
+      // a rename — renaming a live app means downtime and a pm2 startup re-run.
+      name: process.env.PM2_APP_NAME || `basinwx-${branch}`,
       script: 'server/server.js',
       cwd: __dirname,
       env: {


### PR DESCRIPTION
Corrects a documentation/reality mismatch found while preparing the v1.5.0 deploy on linode-prod, and adds the `.dev` bring-up handoff.

## The mismatch

`docs/DEPLOYMENT.md` §1 and `CLAUDE.md` both describe a production layout that doesn't exist. Verified by direct inspection of linode-prod on 2026-08-13 (`pm2 describe`, `git rev-parse`, and matching on-disk data-file counts — forecasts 39,076 / images 29,824, which pin this box as `.com`):

| Docs claimed | Actually deployed |
|---|---|
| `/srv/ubair-website` | `/var/www/ubair-website` |
| runs as `deploy` | runs as `root` |
| pm2 `basinwx-ops` | pm2 `ubair-site` |
| nginx vhost in `sites-enabled` | `sites-enabled` is **empty** |

This matters because #196's own deploy instructions point at `docs/DEPLOYMENT.md` — following it as written would have someone hunting for a `basinwx-ops` app that isn't there.

**The target layout is kept, not deleted.** §1 is now split into **§1a (as deployed)**, **§1b (target)**, and **§1c (how to migrate)**. Every dev-box value is marked *unverified* rather than guessed at — that box was not inspected from here.

## `ecosystem.config.cjs`

Now honours `PM2_APP_NAME`, defaulting to the existing branch-derived name. This lets a box whose pm2 app predates the file adopt it without a rename (`PM2_APP_NAME=ubair-site pm2 start ecosystem.config.cjs`), since renaming a live app means downtime plus a `pm2 startup` re-run.

## The trap worth reading

Documented in both files, because it bit this deployment: **the app serves `public/` off the working tree**, so `git checkout` changes what live traffic sees *immediately*, before any pm2 restart. Checking out `dev` in the live repo to inspect it served dev's frontend against ops's in-memory server for ~4 minutes on basinwx.com. Use `git worktree add /tmp/staging <branch>` instead — everything in this PR was prepared that way.

## `WEBSITE-DEVBOX-HANDOFF-aug13.md`

Terse runbook for bringing `.dev` onto the v1.5.x contract: update/restart/verify commands, the four contract changes it must match (manifest v1.2.0, `/api/monitoring/*`, versioned `/api/health`, manifest-driven uploader), the `/api/filelist.json` breakage, and a `.env` trap.

It states plainly that the fan-out gap is **brc-tools' problem on CHPC, not the dev box's** — consistent with `docs/DEPLOYMENT.md` §7a's finding that `load_config()` and `clyfar/export/to_basinwx.py` read the singular `BASINWX_API_URL`. Deliberately follows the `-mmmDD` temporary-doc convention.

## Ordering

Independent of the release train — verified to auto-merge cleanly against **#193, #195, #197 and #198** in any order (`git merge-tree --write-tree`, all clean). No overlapping hunks: #193 edits `DEPLOYMENT.md` at line 195+, this edits §1; #198 edits `CLAUDE.md` at line 36+, this edits the topology block at line 6.

Slot it before **#196** so the corrections ship with v1.5.0 — otherwise #196's deploy instructions go to production still pointing at a nonexistent `basinwx-ops`.

## Not included

The matching pm2-column fix in `WEBSITE-BRCTOOLS-HANDOFF-aug13.md` — that file arrives with #193, so it's a one-line follow-up afterwards rather than a cross-branch dependency here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)