### PR TITLE
fix(monitoring): exclude server-generated indexes from freshness

### DIFF
--- a/server/__tests__/dataMonitorFreshness.test.js
+++ b/server/__tests__/dataMonitorFreshness.test.js
@@ -1,0 +1,102 @@
+/**
+ * Regression test for the freshness "index trap".
+ *
+ * Observed on linode-dev 2026-08-13: /api/monitoring/freshness reported
+ *   outlooks -> { status: "fresh", ageMinutes: 0 }
+ * on a box that had never received a single outlooks upload. The directory held only
+ * 2026-04 sample files plus outlooks_list.json, which the server rewrites every few
+ * minutes — so the index's mtime, not any producer, was driving the verdict.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { jest } from '@jest/globals';
+
+const HOUR = 60 * 60 * 1000;
+
+let tmpRoot;
+let monitor;
+
+/** Build a fake public/api/static tree and point a DataMonitor at it. */
+async function makeMonitor(manifestDataTypes) {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'freshness-'));
+    const staticDir = path.join(tmpRoot, 'public', 'api', 'static');
+    fs.mkdirSync(staticDir, { recursive: true });
+
+    const { default: DataMonitor } = await import('../monitoring/dataMonitor.js');
+    const m = new DataMonitor();
+    m.staticDir = staticDir;
+    m.manifest = { dataTypes: manifestDataTypes };
+    return m;
+}
+
+function writeFile(monitorInstance, subDir, name, ageMs) {
+    const dir = path.join(monitorInstance.staticDir, subDir);
+    fs.mkdirSync(dir, { recursive: true });
+    const full = path.join(dir, name);
+    fs.writeFileSync(full, '{}');
+    const when = new Date(Date.now() - ageMs);
+    fs.utimesSync(full, when, when);
+    return full;
+}
+
+afterEach(() => {
+    if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+    tmpRoot = undefined;
+    jest.resetModules();
+});
+
+describe('checkDataFreshness — server-generated indexes', () => {
+    // Frequencies are cron expressions, as in DATA_MANIFEST.json. 'ad-hoc' is what
+    // outlooks really carries; parseFrequency falls back to 60 minutes for it.
+    const outlooksManifest = {
+        outlooks: {
+            endpoint: '/api/static/outlooks',
+            schedule: { frequency: 'ad-hoc' },
+        },
+    };
+
+    test('a freshly-rewritten index does not make a dead dataType look fresh', async () => {
+        monitor = await makeMonitor(outlooksManifest);
+
+        // The real dev-box shape: stale producer content, constantly-rewritten index.
+        writeFile(monitor, 'outlooks', 'outlook_20240205_1115.md', 2000 * HOUR);
+        writeFile(monitor, 'outlooks', 'outlooks_list.json', 0);
+
+        const { outlooks } = monitor.checkDataFreshness();
+
+        expect(outlooks.latestFile).not.toBe('outlooks_list.json');
+        expect(outlooks.status).toBe('stale');
+        expect(outlooks.ageMinutes).toBeGreaterThan(60);
+    });
+
+    test('a directory holding only indexes reports no_data, not fresh', async () => {
+        monitor = await makeMonitor(outlooksManifest);
+        writeFile(monitor, 'outlooks', 'outlooks_list.json', 0);
+
+        const { outlooks } = monitor.checkDataFreshness();
+
+        expect(outlooks.status).toBe('no_data');
+        expect(outlooks.ageMinutes).toBeUndefined();
+    });
+
+    test('filelist.json is excluded too, and real uploads still read as fresh', async () => {
+        monitor = await makeMonitor({
+            observations: {
+                endpoint: '/api/static/observations',
+                schedule: { frequency: '*/10 * * * *' },
+            },
+        });
+
+        writeFile(monitor, 'observations', 'map_obs_20260813_2230Z.json', 60 * 1000);
+        writeFile(monitor, 'observations', 'filelist.json', 0);
+
+        const { observations } = monitor.checkDataFreshness();
+
+        expect(observations.status).toBe('fresh');
+        expect(observations.latestFile).toBe('map_obs_20260813_2230Z.json');
+        // totalFiles counts producer-written files only.
+        expect(observations.totalFiles).toBe(1);
+    });
+});

--- a/server/monitoring/dataMonitor.js
+++ b/server/monitoring/dataMonitor.js
@@ -12,6 +12,22 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+/**
+ * Index files the *server* regenerates, not files a producer uploads.
+ *
+ * `filelist.json` is rewritten by `updateFileList()` on every observations/metadata
+ * upload; `outlooks_list.json` is rewritten by `generateOutlooksList`. Their mtime is
+ * therefore always ~now, which makes freshness report a dataType as "fresh" even when no
+ * producer has ever uploaded to it — exactly what `outlooks` did on linode-dev (status
+ * "fresh", ageMinutes 0, on a directory holding nothing but 2026-04 sample files).
+ *
+ * Freshness must be judged on producer-written files only.
+ */
+export const GENERATED_INDEX_FILES = new Set([
+    'filelist.json',
+    'outlooks_list.json',
+]);
+
 class DataMonitor {
     constructor() {
         this.manifestPath = path.join(__dirname, '../../DATA_MANIFEST.json');
@@ -60,6 +76,9 @@ class DataMonitor {
             try {
                 const files = fs.readdirSync(dataDir)
                     .filter(f => f.endsWith('.json') || f.endsWith('.md') || f.endsWith('.png'))
+                    // Server-regenerated indexes would otherwise pin ageMinutes to ~0 forever
+                    // and mask a dead producer. See GENERATED_INDEX_FILES.
+                    .filter(f => !GENERATED_INDEX_FILES.has(f))
                     .map(f => ({
                         name: f,
                         path: path.join(dataDir, f),
@@ -70,7 +89,7 @@ class DataMonitor {
                 if (files.length === 0) {
                     results[dataType] = {
                         status: 'no_data',
-                        message: 'No data files found'
+                        message: 'No data files found (directory holds only server-generated indexes)'
                     };
                     continue;
                 }


### PR DESCRIPTION
Fixes the monitoring bug found while verifying linode-dev (see #204).

## The bug

`/api/monitoring/freshness` judges a dataType by the newest file in its directory — including index files **the server writes itself**:

- `filelist.json` — rewritten by `updateFileList()` on every observations/metadata upload
- `outlooks_list.json` — rewritten by `generateOutlooksList`

Their mtime is therefore always ~now, whether or not a producer is still feeding that directory.

## What it looked like on dev

```json
"outlooks": { "status": "fresh", "ageMinutes": 0, "totalFiles": 7 }
```

on a box that has **never received an outlooks upload** — `grep -c 'Type: outlooks'` over the entire pm2 log returns `0`. The content behind that green status was sample/template files dated 2026-04-17.

A dead producer looked perfectly healthy. That's the exact failure mode these endpoints exist to catch, and the one that would let an upstream die unnoticed through an ozone season.

## The fix

One `.filter()` in `checkDataFreshness()`, plus a named `GENERATED_INDEX_FILES` set carrying the explanation. Freshness and `totalFiles` now count producer-written files only. A directory holding nothing but indexes reports `no_data` instead of `fresh`.

## Verification

Three regression tests pinning the real dev-box shape (stale content + fresh index). **All three fail without the filter and pass with it** — confirmed by reverting the one-line change and re-running.

Full suite: `Tests: 4 failed, 121 passed` — the 4 are the known pre-existing `cameraAnalysisScheduler` baseline, untouched by this change.

## Expected effect once deployed

`outlooks` on dev will flip from `fresh` to `stale`. **That is the correct answer** — nothing is producing outlooks there. Same for any other dataType whose producer is dark.

## Note on merge order

#204 documents this trap as live behaviour in `docs/DEPLOYMENT.md` §7. If that merges first, ping me and I'll follow up with a one-line doc amendment marking it fixed. The two branches don't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)