### PR TITLE
chore: strip -dev for the v1.5.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ubair-website",
-  "version": "1.5.1-dev",
+  "version": "1.5.1",
   "description": "Uintah Basin Air Quality Website",
   "main": "server/server.js",
   "type": "module",


### PR DESCRIPTION
Step 1 of the v1.5.1 release train (CLAUDE.md / `docs/DEPLOYMENT.md` §7a). One line: `package.json` `1.5.1-dev` → `1.5.1`.

## What ships in v1.5.1

| PR | |
|---|---|
| #203 | analytics — sessions, bots, referrers, pipeline tracking, crash fixes |
| #204 | docs — measured linode-dev topology, per-box ingest paths, security state |
| #205 | fix — freshness no longer counts server-generated indexes |

`manifestVersion` stays **1.2.0** — no dataType contract changed, so brc-tools needs no matching release and no producer has to be updated in step with this.

## ⚠️ Do not promote #204/#205 without #203

#203 puts the new analytics code in front of prod's existing `logs/analytics/daily_summary.json`, which was written by the pre-rewrite build and lacks `botPaths` / `referrerSources` / `hourlyDistribution`. That combination is exactly what crash-looped production on 2026-08-13.

It is safe here **only because** #203 also adds `normalizeDailySummary()` to reconcile the shape on load, with regression tests in `server/__tests__/analyticsSummary.test.js`. Promoting the docs and freshness changes while cherry-picking around #203 would reintroduce the crash.

Prod is not at risk *today* — ops's `analytics.js` predates `botPaths` entirely, so it cannot hit that dereference. The risk appears only on promotion, and #203 is the thing that neutralises it.

## Remaining steps after this merges

2. promotion PR — head `dev`, base `ops`, **merge commit** (not squash): `Merge dev into ops: v1.5.1`
3. tag `ops` tip `v1.5.1`
4. `Merge ops into main: v1.5.1 release`
5. reopen `dev` at `1.5.2-dev`
6. on linode-prod: `git pull && pm2 restart ubair-site` (`/var/www/ubair-website`, as `root`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)