### PR TITLE
chore: open v1.5.2-dev

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -338,8 +338,8 @@ so the first question in any investigation is *which box am I actually looking a
 **Version tells you.** `GET /api/health` reports `version` and `manifestVersion`:
 
 ```bash
-curl -fsS https://www.basinwx.com/api/health   # -> "version": "1.5.0"     (tag v1.5.0)
-curl -fsS https://www.basinwx.dev/api/health   # -> "version": "1.5.1-dev"
+curl -fsS https://www.basinwx.com/api/health   # -> "version": "1.5.1"     (tag v1.5.1)
+curl -fsS https://www.basinwx.dev/api/health   # -> "version": "1.5.2-dev"
 ```
 
 `dev` always carries the *next* version with a `-dev` suffix. The dev→ops

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ubair-website",
-  "version": "1.5.1",
+  "version": "1.5.2-dev",
   "description": "Uintah Basin Air Quality Website",
   "main": "server/server.js",
   "type": "module",


### PR DESCRIPTION
Step 5 (final) of the v1.5.1 release train. Restores the invariant that `dev` carries the next `X.Y.Z-dev` while `ops` ships the clean `X.Y.Z`, so the two boxes never report the same version.

## 🛑 Opened as a DRAFT on purpose — do not merge before #207

**#207's head is `dev`.** If this lands first, the promotion carries `1.5.2-dev` into `ops` instead of the clean `1.5.1`, and the release ships the wrong version string.

Correct order:

1. merge **#207** (promotion, merge commit) ✅
2. tag `ops` tip `v1.5.1`
3. `Merge ops into main: v1.5.1 release`
4. mark this ready and merge it

## Contents

- `package.json` → `1.5.2-dev`
- `docs/DEPLOYMENT.md` §7a example versions → `1.5.1` / `1.5.2-dev` (the one place in the docs hardcoding both boxes' expected `/api/health` output; it would otherwise go stale the moment v1.5.1 ships)

Branched from `origin/dev` after #206 squashed, not stacked on another PR's head — per the squash-merge trap in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)