### PR TITLE
feat(aviation): KVEL 17/35 website leg — floor fix + manifest 2.0.0

### DIFF
--- a/DATA_MANIFEST.json
+++ b/DATA_MANIFEST.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "BasinWx Data Pipeline Manifest - Defines all data types, formats, validation rules, and transfer schedules",
-  "lastUpdated": "2026-08-13",
+  "lastUpdated": "2026-08-14",
   "dataTypes": {
     "observations": {
       "description": "Live weather observations from stations",
@@ -623,16 +623,109 @@
               }
             }
           }
+        },
+        "hrrr_kvel_crosswind": {
+          "description": "HRRR sub-hourly runway head/crosswind forecast for KVEL (Vernal Regional). Runways 17/35 per FAA redesignation (true headings 179/359).",
+          "schedule": {
+            "frequency": "55 * * * *",
+            "description": "Automatic - hourly export of the latest HRRR subh run (cron pending install on CHPC)",
+            "timezone": "UTC"
+          },
+          "filename": {
+            "pattern": "forecast_hrrr_kvel_crosswind_YYYYMMDD_HHMMZ.json",
+            "example": "forecast_hrrr_kvel_crosswind_20260813_1800Z.json"
+          },
+          "schema": {
+            "type": "object",
+            "required": [
+              "model",
+              "product",
+              "airport",
+              "runway_headings_deg",
+              "init_time",
+              "valid_times",
+              "series"
+            ],
+            "properties": {
+              "model": {
+                "type": "string",
+                "enum": ["hrrr_subh", "hrrr"]
+              },
+              "product": {
+                "type": "string",
+                "enum": ["aviation_crosswind"]
+              },
+              "airport": {
+                "type": "string",
+                "enum": ["KVEL"]
+              },
+              "name": { "type": "string" },
+              "lat": { "type": "number" },
+              "lon": { "type": "number" },
+              "elevation_m": { "type": "number" },
+              "runway_headings_deg": {
+                "type": "array",
+                "description": "Degrees TRUE, top-level. Drives every column pair; series keys are derived from these values.",
+                "items": { "type": "integer", "minimum": 0, "maximum": 360 },
+                "minItems": 2,
+                "maxItems": 2
+              },
+              "init_time": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+              },
+              "generated_at": {
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+              },
+              "valid_times": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+                }
+              },
+              "forecast_minutes": {
+                "type": "array",
+                "items": { "type": "integer", "minimum": 0 }
+              },
+              "variables": {
+                "type": "object",
+                "description": "Per-series label/units/precision metadata (unread by aviation.js today)"
+              },
+              "series": {
+                "type": "object",
+                "description": "Every array MUST be index-aligned with valid_times; short arrays render as em-dashes, not errors. Per-runway keys are 'headwind_kt_' / 'crosswind_kt_' + String(heading).padStart(3,'0') for each heading in runway_headings_deg — currently _179 and _359.",
+                "required": [
+                  "wind_speed_kt",
+                  "wind_dir_deg",
+                  "headwind_kt_179",
+                  "crosswind_kt_179",
+                  "headwind_kt_359",
+                  "crosswind_kt_359"
+                ],
+                "properties": {
+                  "wind_speed_kt": { "type": "array", "items": { "type": ["number", "null"] } },
+                  "wind_dir_deg": { "type": "array", "items": { "type": ["number", "null"] } },
+                  "gust_kt": { "type": "array", "items": { "type": ["number", "null"] } }
+                },
+                "patternProperties": {
+                  "^(headwind|crosswind)_kt_\\d{3}$": { "type": "array", "items": { "type": ["number", "null"] } }
+                }
+              }
+            }
+          }
         }
       },
       "validation": {
         "maxFileSize": "10MB",
-        "totalFilesPerRun": 63,
+        "totalFilesPerRun": 64,
         "filesPerProduct": {
           "possibility_heatmap": 31,
           "exceedance_probabilities": 1,
           "percentile_scenarios": 31,
-          "hrrr_surface_layers": 4
+          "hrrr_surface_layers": 4,
+          "hrrr_kvel_crosswind": 1
         }
       },
       "ozoneCategories": {

--- a/WEBSITE-BRCTOOLS-HANDOFF-aug13.md
+++ b/WEBSITE-BRCTOOLS-HANDOFF-aug13.md
@@ -217,8 +217,9 @@ dramatic one.
 
 **Endpoint:** `POST /api/upload/forecasts` (shared dataType, distinguished by filename prefix)
 **Filename:** `forecast_hrrr_kvel_crosswind_YYYYMMDD_HHMMZ.json`
-**Manifest entry:** none yet — the schema below is extracted directly from the consumer,
-`public/js/aviation.js:33-84`. Coordinate a manifest addition when you build it.
+**Manifest entry:** `DATA_MANIFEST.json` → `dataTypes.forecasts.products.hrrr_kvel_crosswind`
+(added in manifest 2.0.0, 2026-08-14). The schema below is extracted directly from the
+consumer, `public/js/aviation.js:33-84`, and matches the manifest entry.
 
 > ⚠️ **The apr27 handoff doc got this wrong.** It specified `crosswind_kt_rwy16` /
 > `crosswind_kt_rwy34` and `metadata.runway_headings_deg_true`. Building to that spec renders
@@ -228,26 +229,28 @@ dramatic one.
 ```jsonc
 {
   "product": "aviation_crosswind",   // exact string; else header falls back to "hrrr"
-  "model": "hrrr",                   // shown in the <h2> when product matches
+  "model": "hrrr_subh",              // shown in the <h2> when product matches
   "init_time": "2026-08-13T18:00:00Z",  // rendered verbatim as a string
-  "runway_headings_deg": [160, 340],    // TOP-LEVEL. Degrees true. Drives all column pairs.
+  "runway_headings_deg": [179, 359],    // TOP-LEVEL. Degrees true. Drives all column pairs.
   "valid_times": ["2026-08-13T19:00:00Z", "..."],   // drives row count
   "series": {
     "wind_speed_kt":     [12, 14, ...],   // knots
     "wind_dir_deg":      [210, 215, ...], // degrees true
-    "headwind_kt_160":   [ 8,  9, ...],   // key = "headwind_kt_" + String(heading).padStart(3,'0')
-    "crosswind_kt_160":  [ 9, 11, ...],   // key = "crosswind_kt_" + same tag
-    "headwind_kt_340":   [-8, -9, ...],
-    "crosswind_kt_340":  [-9,-11, ...]
+    "gust_kt":           [18, 21, ...],   // producer sends it; the page currently ignores it
+    "headwind_kt_179":   [ 8,  9, ...],   // key = "headwind_kt_" + String(heading).padStart(3,'0')
+    "crosswind_kt_179":  [ 9, 11, ...],   // key = "crosswind_kt_" + same tag
+    "headwind_kt_359":   [-8, -9, ...],
+    "crosswind_kt_359":  [-9,-11, ...]
   }
 }
 ```
 
 **Every `series` array must be index-aligned with `valid_times`.** Missing/short arrays render
 as `—`, not an error — so a silent misalignment looks like partial data, not a failure.
-Column headers are derived as `Rwy` + `round(heading/10)` → `160` → `Rwy16`, `340` → `Rwy34`.
+Column headers are derived as `Rwy` + `floor(heading/10)` → `179` → `Rwy17`, `359` → `Rwy35`.
 
-Confirm KVEL's current runway headings against the live FAA chart before hardcoding.
+Runway headings **resolved 2026-08-13**: FAA chart confirmed 17/35 (true 179/359), shipped
+in brc-tools #59 / v0.1.1.
 
 ---
 
@@ -354,7 +357,9 @@ it in the producer.
 1. Which producer currently uploads clustering forecasts, and why does it not fan out?
 2. Should `road-forecast` run hourly (matching HRRR) or 3-hourly (matching the website's 1 h
    cache)? Hourly is safer given the hard 3 h reject.
-3. Confirm current KVEL runway headings against the FAA chart before hardcoding `[160, 340]`.
+3. ~~Confirm current KVEL runway headings against the FAA chart before hardcoding.~~
+   **Resolved 2026-08-13** — FAA chart confirmed 17/35 (true headings `[179, 359]`),
+   shipped in brc-tools #59 / v0.1.1.
 4. Retention: `.com` is carrying 100 k+ files with no pruning policy. Agree one before the
    Clyfar producers restart in November.
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -15,7 +15,7 @@ Statuses: 🔜 pending · 🔄 in-progress · ✅ done · ⏸️ deferred (decis
 | ✓ | Item | Notes |
 |---|---|---|
 | 🔜 | **Promote `dev` → `ops`** to land 21 commits on `.com` | PRs #142, #178–#188 plus 7 fixes; needs a deliberate `dev→ops` PR + `pm2 restart basinwx-ops` |
-| 🔜 | **Fix three dark dataTypes** (road-forecast, kvel_crosswind, hrrr_surface_layers) | brc-tools side; full handoff in `WEBSITE-BRCTOOLS-HANDOFF-apr27.md` |
+| 🔜 | **Fix three dark dataTypes** (road-forecast, kvel_crosswind, hrrr_surface_layers) | brc-tools side; full handoff in `WEBSITE-BRCTOOLS-HANDOFF-aug13.md` (apr27 doc deleted) |
 | 🔜 | **Fan-out gap for `forecasts/` to `.dev`** | `.com` has 100s of clustering files, `.dev` has zero. brc-tools uploader inconsistency. |
 | 🔜 | **Operational health page** (`/admin/health`) | per-dataType last-upload time + expected cadence + pm2 uptime + git HEAD; tier-3 of the apr26 plan |
 | 🔜 | **Upload-freshness alarm** | cron walks `public/api/static/`, emails via `reportEmailService` if any dataType exceeds expected cadence |
@@ -48,7 +48,7 @@ Statuses: 🔜 pending · 🔄 in-progress · ✅ done · ⏸️ deferred (decis
 | ✓ | Item | Notes |
 |---|---|---|
 | 🔜 | **Add `road-forecast` schema to `DATA_MANIFEST.json`** | currently undocumented dataType; brc-tools is the contract-holder but website-side manifest is where consumers look |
-| 🔜 | **Add `forecast_hrrr_kvel_crosswind_*` schema to `DATA_MANIFEST.json`** | extracted in `WEBSITE-BRCTOOLS-HANDOFF-apr27.md` §DATATYPE 2; copy-pin |
+| ✅ | **Add `forecast_hrrr_kvel_crosswind_*` schema to `DATA_MANIFEST.json`** | done in manifest 2.0.0 (2026-08-14), KVEL 17/35 contract. Do **not** copy-pin the deleted apr27 §DATATYPE 2 schema — its `crosswind_kt_rwy16`-style keys were wrong and render an empty table |
 | 🔜 | **CHPC↔website contract test** | small CI/cron job that POSTs synthetic JSON for every dataType, verifies it lands; would have caught the dark-dataTypes regression |
 
 ## Documentation hygiene (see `REVIEW-DOCS-apr27.md`)

--- a/docs/MANIFEST-CHANGELOG.md
+++ b/docs/MANIFEST-CHANGELOG.md
@@ -1,5 +1,33 @@
 # Data Manifest Change Log
 
+## Version 2.0.0 (2026-08-14)
+
+### Type: Major - Contract Correction
+
+**Summary:** First declaration of `dataTypes.forecasts.products.hrrr_kvel_crosswind` —
+the HRRR sub-hourly runway head/crosswind forecast for KVEL (Vernal Regional) — under
+the corrected KVEL 17/35 contract (FAA redesignation: true headings 179/359, series keys
+`headwind_kt_179`/`crosswind_kt_179` and `headwind_kt_359`/`crosswind_kt_359`).
+
+### Changes Made
+
+- **Added:** `dataTypes.forecasts.products.hrrr_kvel_crosswind` — filename pattern
+  `forecast_hrrr_kvel_crosswind_YYYYMMDD_HHMMZ.json`, hourly schedule (`55 * * * *`),
+  full payload schema keyed off the top-level `runway_headings_deg` array. Rides the
+  existing `forecasts` endpoint; no upload-route change.
+- **Counters:** `validation.filesPerProduct` gains `"hrrr_kvel_crosswind": 1`;
+  `totalFilesPerRun` 63 → 64.
+
+### Why MAJOR
+
+The previously *documented* (never published) contract — `WEBSITE-BRCTOOLS-HANDOFF-apr27.md`
+§DATATYPE 2, since deleted — used `*_kt_160`/`*_kt_340` series keys, so the field-name rule
+in `docs/MANIFEST-GUIDE.md` applies. 2.0.0 is also the coordination signal promised in
+brc-tools PR #59 / tag v0.1.1 (the producer, which released first on 2026-08-13). Zero
+KVEL files have ever been uploaded to `.com` or `.dev`, so no data migration is needed.
+
+---
+
 ## Version 1.2.0 (2026-08-13)
 
 ### Type: Minor - Additive

--- a/public/js/aviation.js
+++ b/public/js/aviation.js
@@ -46,7 +46,7 @@ function buildTable(payload) {
 
     const headers = ['Time (UTC)', 'Wind kt', 'Dir°'];
     for (const heading of runways) {
-        const rwy = String(Math.round(heading / 10)).padStart(2, '0');
+        const rwy = String(Math.floor(heading / 10)).padStart(2, '0');
         headers.push(`HW Rwy${rwy}`);
         headers.push(`XW Rwy${rwy}`);
     }


### PR DESCRIPTION
Executes the website leg of the KVEL 16/34 → 17/35 mini-cycle (handoff: `HANDOFF-KVEL-MINI-CYCLE-aug13.md`, committed on `chore/pipeline-unblockers-aug13` at `8e82965`). The producer side is already released: brc-tools v0.1.1 / PR #59 emits `runway_headings_deg: [179, 359]` with series keys `*_kt_179`/`*_kt_359`.

## Changes (five files, one code change)

- **`public/js/aviation.js:49`** — `Math.round` → `Math.floor` for runway column labels. 179 → `Rwy17`, 359 → `Rwy35`, matching the producer's `heading // 10`. Without this, real KVEL data renders **Rwy18/36**.
- **`DATA_MANIFEST.json`** — **2.0.0**; first-ever `dataTypes.forecasts.products.hrrr_kvel_crosswind` entry (mirrors `hrrr_surface_layers` style; payload `product` field is `"aviation_crosswind"`, intentionally distinct from the key). Counters: `filesPerProduct` + `"hrrr_kvel_crosswind": 1`, `totalFilesPerRun` 63 → 64. No upload-route change — KVEL rides the existing `forecasts` dataType by filename prefix.
- **`docs/MANIFEST-CHANGELOG.md`** — 2.0.0 entry. MAJOR per the `MANIFEST-GUIDE.md` field-name rule (the previously documented, never-published contract used `*_kt_160`/`*_kt_340`) and it's the coordination signal promised in brc-tools #59 / v0.1.1. Zero legacy files → no migration.
- **`WEBSITE-BRCTOOLS-HANDOFF-aug13.md`** — §TARGET 2 example corrected (`[179, 359]`, `hrrr_subh`, `gust_kt` added), header rule `round`→`floor`, Open Question 3 marked resolved. Doc kept per its own expiry rule.
- **`docs/IMPROVEMENTS.md`** — KVEL schema row ✅; removed the instruction to copy-pin the deleted apr27 schema (it was wrong — renders an empty table); dark-dataTypes row repointed apr27 → aug13.

## Decisions already locked with JRL (2026-08-13, don't re-litigate)

MAJOR → 2.0.0; no `runway_designators` payload field (both sides floor-derive); rehearse on `.dev` before dev→ops promotion; cron installs last, unpinned.

## Testing

- `DATA_MANIFEST.json` parses; new entry verified programmatically (required keys, series keys `_179`/`_359`, counters).
- `node --check public/js/aviation.js` clean.
- `npm test`: 121 passed, 4 failed — the 4 failures are in `cameraAnalysisScheduler.test.js` and reproduce identically on a clean `dev` tree (pre-existing config-default drift, untouched by this PR).

## After merge (sequencing)

1. Deploy to `.dev` (pull + pm2 restart) — **note: `.dev` nginx also needs `client_max_body_size` raised; it's currently 413-rejecting the ~1.5 MB `hrrr_surface_layers` uploads that `.com` accepts**
2. One-off rehearsal upload from CHPC to `.dev` only (`--server-url https://basinwx.dev`)
3. Verify Rwy17/35 rendering + `manifestVersion: "2.0.0"` on `/api/health`
4. Promote dev→ops, deploy `.com`
5. JRL installs the cron on notchpeak1 (`55 * * * *`)
6. brc-tools follow-up PR to retire the stale BLOCKED comments

⚠️ If `chore/housekeeping-aug13` (forked pre-1.2.0) merges after this, it will conflict on `DATA_MANIFEST.json` and tries to resurrect the deleted apr27 handoff — rebase it, don't let it win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqVQKTvUAGwLdQpym6sVqt